### PR TITLE
deploy: add initial vllm worker chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
     exclude: .devcontainer
   - id: check-toml
   - id: check-yaml
+    exclude: ^deploy/Kubernetes/[^/]+/(charts|tests)/[^/]+/templates/
   - id: check-shebang-scripts-are-executable
   - id: end-of-file-fixer
     types_or: [c, c++, cuda, proto, textproto, java, python]

--- a/deploy/Kubernetes/.gitignore
+++ b/deploy/Kubernetes/.gitignore
@@ -1,0 +1,1 @@
+dev_values.yaml

--- a/deploy/Kubernetes/worker/charts/vllm/Chart.yaml
+++ b/deploy/Kubernetes/worker/charts/vllm/Chart.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: 1.0.0
+description: Triton Distributed Worker for vLLM
+icon: https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-d@2x.png
+name: triton-distributed_worker-vllm
+version: 1.0.0

--- a/deploy/Kubernetes/worker/charts/vllm/templates/_helpers.tpl
+++ b/deploy/Kubernetes/worker/charts/vllm/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Annotation Groups
+{{- define "triton.annotations.default" }}
+triton-distributed: "{{ .Release.Name }}.{{ .Chart.AppVersion | default "0.0" }}"
+{{-   with .Values.kubernetes }}
+{{-     with .annotations }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{- end -}}
+
+{{- define "triton.annotations.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+{{-   template "triton.annotations.default" . }}
+{{- end -}}
+
+# Label Groups
+{{- define "triton.labels.default" }}
+{{-   template "triton.label.appInstance" . }}
+{{-   template "triton.label.appName" . }}
+{{-   template "triton.label.appPartOf" . }}
+{{-   template "triton.label.appVersion" . }}
+{{- end -}}
+
+{{- define "triton.labels.chart" }}
+{{-   template "triton.labels.default" . }}
+{{-   template "triton.label.appManagedBy" . }}
+{{-   template "triton.label.chart" . }}
+{{-   with .Values.kubernetes }}
+{{-     with .labels }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{-   template "triton.label.release" . }}
+{{- end -}}
+
+# Label Values
+{{- define "triton.label.appInstance" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "triton.label.appManagedBy" }}
+{{-   $service_name := "triton-distributed" }}
+{{-   with .Release.Service }}
+{{-     $service_name = . }}
+{{-   end }}
+app.kubernetes.io/managed-by: {{ $service_name }}
+{{- end }}
+
+{{- define "triton.label.appName" }}
+app.kubernetes.io/name: {{ required "Property '.triton.componentName' is required." .Values.triton.componentName }}
+{{- end }}
+
+{{- define "triton.label.appPartOf" }}
+{{-   $part_of := "triton-distributed" }}
+{{-   with .Values.kubernetes }}
+{{-     with .partOf }}
+{{-       $part_of = . }}
+{{-     end }}
+{{-   end }}
+app.kubernetes.io/part-of: {{ $part_of }}
+{{- end }}
+
+{{- define "triton.label.appVersion" }}
+app.kubernetes.io/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+helm.sh/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.release" }}
+release: "{{ .Chart.Name }}_v{{ .Chart.Version | default "0.0" }}"
+{{- end }}

--- a/deploy/Kubernetes/worker/charts/vllm/templates/worker-deployment.yaml
+++ b/deploy/Kubernetes/worker/charts/vllm/templates/worker-deployment.yaml
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $triton_image_name := "" }}
+{{- with $.Values.image }}
+{{-   $triton_image_name = required "Property '.image.name' is required." .name }}
+{{- else }}
+{{-   fail "Property '.image' is required." }}
+{{- end }}
+{{- $component_name := "" }}
+{{- $instance_count := 1 }}
+{{- $k8s_liveness_delay := 10 }}
+{{- $k8s_liveness_enabled := true }}
+{{- $k8s_liveness_fail := 15 }}
+{{- $k8s_liveness_period := 2 }}
+{{- $k8s_liveness_success := 1 }}
+{{- $k8s_readiness_delay := 10 }}
+{{- $k8s_readiness_enabled := true }}
+{{- $k8s_readiness_fail := 15 }}
+{{- $k8s_readiness_period := 2 }}
+{{- $k8s_readiness_success := 1 }}
+{{- $request_plane_kind := "nats-io" }}
+{{- $request_plane_name := "triton-distributed_request-plane" }}
+{{- $request_plane_port := 30222 }}
+{{- $parallel_pipeline := 1 }}
+{{- $parallel_tensor := 1 }}
+{{- $parallel_world := 1 }}
+{{- $port_data := 9346 }}
+{{- $port_health := 8000 }}
+{{- $port_metrics := 9347 }}
+{{- $port_request := 9345 }}
+{{- $triton_cpu := 4 }}
+{{- $triton_ephemeral := "1Gi" }}
+{{- $triton_gpu := 1 }}
+{{- $triton_logging_iso8601 := 0 }}
+{{- $triton_logging_verbose := 0 }}
+{{- $triton_memory := "16Gi" }}
+{{- $triton_shared := "512Mi" }}
+{{- with $.Values.kubernetes }}
+{{-   with .checks }}
+{{-     with .liveness }}
+{{-       $k8s_liveness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_liveness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_liveness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_liveness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_liveness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-     with .readiness }}
+{{-       $k8s_readiness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_readiness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_readiness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_readiness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_readiness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.triton }}
+{{-   $component_name = required "Property '.triton.componentName' is required." .componentName }}
+{{-   with .distributed }}
+{{-     with .manifold }}
+{{-       with .serverKind }}
+{{-         $request_plane_kind = . }}
+{{-       end }}
+{{-       with .serviceName }}
+{{-         $request_plane_name = . }}
+{{-       end }}
+{{-       with .servicePort }}
+{{-         $request_plane_port = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{-   with .instance }}
+{{-     with .count }}
+{{-       $instance_count = (int .) }}
+{{-     end }}
+{{-     with .parallelism }}
+{{-       with .pipeline }}
+{{-         $parallel_pipeline = (int .) }}
+{{-       end }}
+{{-       with .tensor }}
+{{-         $parallel_tensor = (int .) }}
+{{-       end }}
+{{-       $parallel_world = mul $parallel_pipeline $parallel_tensor }}
+{{-     end }}
+{{-   end }}
+{{-   with .logging }}
+{{-     if .useIso8601 }}
+{{-       $triton_logging_iso8601 = 1 }}
+{{-     end }}
+{{-     if .verbose }}
+{{-       $triton_logging_verbose = 1 }}
+{{-     end }}
+{{-   end }}
+{{-   with .ports }}
+{{-     with .data }}
+{{-       $port_data = (int .) }}
+{{-     end }}
+{{-     with .health }}
+{{-       $port_health = (int .) }}
+{{-     end }}
+{{-     with .metrics }}
+{{-       $port_metrics = (int .) }}
+{{-     end }}
+{{-     with .request }}
+{{-       $port_request = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .resources }}
+{{-     with .cpu }}
+{{-       $triton_cpu = (int .) }}
+{{-     end }}
+{{-     with .ephemeral }}
+{{-       $triton_ephemeral = . }}
+{{-     end }}
+{{-     with .gpu }}
+{{-       $triton_gpu = (int .count) }}
+{{-     end }}
+{{-     with .memory }}
+{{-       $triton_memory = . }}
+{{-     end }}
+{{-     with .sharedMemory }}
+{{-       $triton_shared = . }}
+{{-     end }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+{{- $model_repo_path := "/var/run/models" }}
+{{- with $.Values.modelRepository }}
+{{-   with .path }}
+{{-     $model_repo_path = trimSuffix "/" . }}
+{{-   end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}
+  annotations:
+{{- include "triton.annotations.chart" . | indent 4 }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: worker
+{{- include "triton.labels.chart" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}
+      app.kubernetes.io/component: worker
+  replicas: {{ $instance_count }}
+  template:
+    metadata:
+      annotations:
+{{- include "triton.annotations.chart" . | indent 8 }}
+      labels:
+        app: {{ $.Release.Name }}
+        app.kubernetes.io/component: worker
+{{- include "triton.labels.chart" . | indent 8 }}
+    spec:
+{{- if ne $triton_gpu 0 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu
+                operator: Exists
+{{-   with $.Values.triton }}
+{{-     with .resources }}
+{{-       with .gpu }}
+{{-         with .product }}
+{{-           if len . }}
+              - key: nvidia.com/gpu.product
+                operator: In
+                values:
+{{            toYaml . | indent 16 }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      containers:
+      - name: triton
+        command:
+        - --model-repository={{ $model_repo_path }}
+{{- if $triton_logging_iso8601 }}
+        - --iso8601
+{{- end}}
+{{- if $triton_logging_verbose }}
+        - --verbose
+{{- end }}
+        env:
+        - name: TRITON_COMPONENT_NAME
+          value: {{ $component_name | quote }}
+{{- if gt $parallel_world 1 }}
+        - name: TRITON_LLM_PP
+          value: {{ $parallel_pipeline | quote }}
+        - name: TRITON_LLM_TP
+          value: {{ $parallel_tensor | quote }}
+{{- end }}
+        - name: TRITON_request_plane_kind
+          value: {{ $request_plane_kind | quote }}
+        - name: TRITON_request_plane_name
+          value: {{ $request_plane_name | quote }}
+        - name: TRITON_request_plane_port
+          value: {{ $request_plane_port | quote }}
+        - name: TRITON_MODEL_REPOSITORY
+          value: {{ $model_repo_path | quote }}
+{{- if ne $port_data 9346 }}
+        - name: TRITON_PORT_DATA
+          value: {{ $port_data | quote }}
+{{- end }}
+{{- if ne $port_health 8000 }}
+        - name: TRITON_PORT_HEALTH
+          value: {{ $port_health | quote }}
+{{- end }}
+{{- if ne $port_metrics 9347 }}
+        - name: TRITON_PORT_METRICS
+          value: {{ $port_metrics | quote }}
+{{- end }}
+{{- if ne $port_request 9345 }}
+        - name: TRITON_PORT_REQUEST
+          value: {{ $port_request | quote }}
+{{- end }}
+{{- if false }}
+# What are these and are they needed? HELP!
+        - name: VLLM_ATTENTION_BACKEND
+          value: 0
+        - name: VLLM_CONTEXT_WORKERS
+          value: 0
+        - name: VLLM_CONTEXT_TP_SIZE
+          value: 0
+        - name: VLLM_DATA_PLANE_BACKEND
+          value: 0
+        - name: VLLM_GENERATE_TP_SIZE
+          value: 0
+        - name: VLLM_GENERATE_WORKERS
+          value: 0
+        - name: VLLM_TORCH_HOST
+          value: 0
+        - name: VLLM_TORCH_PORT
+          value: 0
+        - name: VLLM_WORKER_ID
+          value: 0
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: 0
+{{- end }}
+        image: {{ $triton_image_name }}
+        imagePullPolicy: IfNotPresent
+{{- if $k8s_liveness_enabled }}
+        livenessProbe:
+          failureThreshold: {{ $k8s_liveness_fail }}
+          httpGet:
+            path: /v2/health/live
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_liveness_delay }}
+          periodSeconds: {{ $k8s_liveness_period }}
+          successThreshold: {{ $k8s_liveness_success }}
+{{- end }}
+        ports:
+        - containerPort: {{ $port_health }}
+          name: health
+        - containerPort: {{ $port_request }}
+          name: request
+        - containerPort: {{ $port_data }}
+          name: data
+        - containerPort: {{ $port_metrics }}
+          name: metrics
+{{- if $k8s_readiness_enabled }}
+        readinessProbe:
+          failureThreshold: {{ $k8s_readiness_fail }}
+          httpGet:
+            path: /v2/health/ready
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_readiness_delay }}
+          periodSeconds: {{ $k8s_readiness_period }}
+          successThreshold: {{ $k8s_readiness_success }}
+{{- end }}
+        resources:
+          limits:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- if gt $triton_gpu 0 }}
+            nvidia.com/gpu: {{ $triton_gpu }}
+{{- end }}
+          requests:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- if gt $triton_gpu 0 }}
+            nvidia.com/gpu: {{ $triton_gpu }}
+{{- end }}
+        volumeMounts:
+{{- with $.Values.modelRepository }}
+{{-   with .volumeMounts }}
+{{-     range . }}
+{{-       $mount_path := $model_repo_path }}
+{{-       $volume_name := required "Property '.modelRepository.volumeMounts[*].name' is required." .name }}
+{{-       if eq "shared-memory" $volume_name }}
+{{-         fail "Property '.modelRepository.volumeMounts[*].name' cannot be `shared-memory` because it is a reserved name." }}
+{{-       end }}
+{{-       with .path }}
+{{-         $mount_path = printf "%s/%s" $model_repo_path (trimPrefix "/" .) }}
+{{-         if regexMatch "/\\.\\./?" $mount_path }}
+{{-           fail (printf "Value of property `.modelRepository.volumeMounts[*].path' `%s` is illegal because `%s` is not a sub-directory of `%s`." . (clean $mount_path) $model_repo_path) }}
+{{-         end }}
+{{-       end }}
+        - mountPath: {{ $mount_path }}
+          name: {{ $volume_name  }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+        - mountPath: /dev/shm
+          name: shared-memory
+{{- with $.Values.image }}
+{{-   with .pullSecrets }}
+{{-     if len . }}
+      imagePullSecrets:
+{{        toYaml . | indent 6 }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      tolerations:
+{{- with $.Values.triton }}
+{{-   with .resources }}
+{{-     with .gpu }}
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.kubernetes }}
+{{-   with .tolerations }}
+{{      toYaml . | indent 6 }}
+{{-   end }}
+{{- end }}
+      volumes:
+{{- with $.Values.modelRepository }}
+{{-   with .volumeMounts }}
+{{-     range . }}
+      - name: {{ required "Property '.modelRepository.volumeMounts.name' is required." .name  }}
+        persistentVolumeClaim:
+          claimName: {{ required "Property '.modelRepository.volumeMounts.persistentVolumeClaim' is required." .persistentVolumeClaim }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ $triton_shared }}

--- a/deploy/Kubernetes/worker/charts/vllm/values.schema.json
+++ b/deploy/Kubernetes/worker/charts/vllm/values.schema.json
@@ -1,0 +1,516 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "copyright": [
+    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.",
+    "SPDX-License-Identifier: Apache-2.0",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License.",
+    "You may obtain a copy of the License at",
+    "http://www.apache.org/licenses/LICENSE-2.0",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
+  "properties": {
+    "image": {
+      "description": "Configuration options related to the Triton Distributed Worker container image.",
+      "properties": {
+        "pullSecrets": {
+          "description": "Optional list of pull secrets to be used when downloading the Triton Distributed Worker container image.",
+          "oneOf": [
+            {
+              "items": [
+                {
+                  "properties": {
+                    "name": {
+                      "$ref": "#/$defs/kubernetes_label",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "name": {
+          "description": "Name of the container image containing the version of Triton Distributed Worker container image to be used.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "kubernetes": {
+      "description": "Configurations option related to the Kubernetes objects created by the chart.",
+      "properties": {
+        "checks": {
+          "description": "Optional configuration options controlling how the cluster monitors the health of Triton Distributed Worker deployment(s).",
+          "properties": {
+            "liveness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed Worker instance is \"alive\" and responsive.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"alive\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster begins to attempt to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is healthy.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "readiness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed Worker instance is ready.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"ready\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster begins to attempt to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is ready.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+        "labels": {
+          "description": "Optional set of labels to be applied to created Kubernetes objects. These labels can be used for association with a preexisting service object.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "tolerations": {
+          "description": "Tolerations applied to every pod deployed as part of this deployment.",
+          "oneOf": [
+            {
+              "items": { "type": "object" },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "modelRepository": {
+      "description": "Configuration options related to the model repository used by the Triton Distributed Worker to load model(s).",
+      "properties": {
+        "path": {
+          "description": "Local file-system path within the container to the model repository.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "volumeMounts": {
+          "description": "Persistent volumes to be mounted with the container.",
+          "oneOf": [
+            {
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "Name to associate the volume mount with. Volume mount names must be unique and cannot contain spaces or special characters.",
+                    "$ref": "#/$defs/kubernetes_label"
+                  },
+                  "path": {
+                    "description": "Path relative to model repository's root path. When not provided, the volume is mounted to the root of the repository. Overlapping mount paths can cause errors during container deployment.",
+                    "oneOf": [
+                      { "type": "string" },
+                      { "type": "null" }
+                    ]
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "Name of the persistent volume claim used to mount a folder containing the model(s) Triton will load.",
+                    "$ref": "#/$defs/kubernetes_label"
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "name",
+                  "persistentVolumeClaim"
+                ]
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "triton": {
+      "description": "Configuration options related to the operation of Triton Distributed Worker.",
+      "properties": {
+        "componentName": {
+          "description": "Name of the Triton Distributed Worker in the distributed deployment.",
+          "pattern": "^[a-z]([a-z0-9_\\-]{0,29}[a-z0-9])?$",
+          "type": "string"
+        },
+        "distributed": {
+          "description": "Configuration options related to organization of Triton Distributed workflows.",
+          "properties": {
+            "requestPlane": {
+              "description": "Configuration options related to connecting the Triton Distributed Worker to its Triton Distributed Request Plane.",
+              "properties": {
+                "serverKind": {
+                  "description": "Kind of server providing Triton Distributed Request Plane functionality. Supported options: 'nats-io'.",
+                  "oneOf": [
+                    {
+                      "pattern": "^nats-io$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "serviceName": {
+                  "description": "Name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.",
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
+                },
+                "servicePort": {
+                  "description": "Networking port to be used to interact with the Triton Distributed Request Plane.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "instance": {
+              "description": "Optional configuration options related to the number of Triton Distributed Worker pods are deployed.",
+              "properties": {
+                "count": {
+                  "description": "Number of worker instances (whole model) to be deployed as part of this helm chart.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "parallelism": {
+                  "description": "Optional configuration options related to how work for a single model is spread across multiple pods. When the product of `pipeline`*`tensor` is greater than 1, multiple pods will be deployed as a single logical worker.",
+                  "properties": {
+                    "pipeline": {
+                      "description": "Pipeline parallelism involves sharding the model (vertically) into chunks, where each chunk comprises a subset of layers that is executed on a separate device.",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type": "null" }
+                      ]
+                    },
+                    "tensor": {
+                      "description": "Tensor parallelism involves sharding (horizontally) individual layers of the model into smaller, independent blocks of computation that can be executed on different devices.",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type": "null" }
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    { "type": "object" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "logging": {
+              "description": "Logging configuration options specific to Triton Distributed Worker.",
+              "properties": {
+                "useIso8601": {
+                  "description": "When `true` Triton Distributed Worker logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "verbose": {
+                  "description": "When `true` Triton Distributed Worker uses verbose logging; otherwise standard logging is used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "ports": {
+              "description": "Configuration options for the management of the Triton Distributed Worker exposed.",
+              "properties": {
+                "data": {
+                  "description": "Container port exposed to enable Triton Distributed Worker data-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "health": {
+                  "description": "Container port exposed to enable Triton Distributed Worker Kubernetes health reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "metrics": {
+                  "description": "Container port exposed to enable Triton Distributed Worker metrics reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "request": {
+                  "description": "Container port exposed to enable Triton Distributed Worker request-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "resources": {
+              "description": "Configuration options related to the resources assigned to Triton Distributed Worker and loaded model(s).",
+              "properties": {
+                "cpu": {
+                  "description": "Number of logical CPU cores required by the Triton Distributed Worker and loaded model(s).",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "ephemeral": {
+                  "description": "Ephemeral storage (aka local disk usage) allowance. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type": "null" }
+                  ]
+                },
+                "gpu": {
+                  "description": "Configuration options related GPU resources to be assigned to the Triton Distributed Worker and loaded model(s).",
+                  "properties": {
+                    "count": {
+                      "description": "Number of GPUs required by the Triton Distributed Worker and loaded model(s).",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type" : "null" }
+                      ]
+                    },
+                    "product": {
+                      "description": "List of the GPUs support `.model` and to which Triton Distributed Worker instances can be deployed.",
+                      "oneOf": [
+                        {
+                          "items": {
+                            "$ref": "#/$defs/kubernetes_label"
+                          },
+                          "type": "array"
+                        },
+                        { "type": "null" }
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    { "type": "object" },
+                    { "type": "null" }
+                  ]
+                },
+                "memory": {
+                  "description": "Amount of CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s). Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                },
+                "sharedMemory": {
+                  "description": "Amount of shared CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s). Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": [
+        "componentName"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "triton"
+  ],
+  "type": "object",
+  "$defs": {
+    "container_port": {
+      "maximum": 65535,
+      "minimum": 1025,
+      "type": "integer"
+    },
+    "kubernetes_label": {
+      "pattern": "^[a-z0-9]([a-z0-9_\\-\\/\\.]{0,61}[a-z0-9])?$",
+      "type": "string"
+    },
+    "kubernetes_units": {
+      "pattern": "^\\d+[GKMgkm]i$",
+      "type": "string"
+    },
+    "service_port": {
+      "maximum": 32767,
+      "minimum": 30000,
+      "type": "integer"
+    }
+  }
+}

--- a/deploy/Kubernetes/worker/charts/vllm/values.yaml
+++ b/deploy/Kubernetes/worker/charts/vllm/values.yaml
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `image` contains configuration options related to the Triton Distributed Worker container image.
+image: # (required)
+  # `image.pullSecrets` is an optional list of pull secrets to be used when downloading the Triton Distributed Worker container image.
+  pullSecrets: [] # (optional)
+  # - name: pull-secret-name
+  # `image.name` is the name of the container image containing the version of Triton Distributed Worker container image to be used.
+  name: # (required)
+
+# `kubernetes` contains configurations option related to the Kubernetes objects created by the chart.
+kubernetes: # (optional)
+  # `kubernetes.annotations` is an optional set of annotations to be applied to create Kubernetes objects.
+  annotations: [] # (optional)
+  # `kubernetes.checks` are optional configuration options controlling how the cluster monitors the health of Triton Distributed Worker deployment(s).
+  checks:
+    # `kubernetes.checks.liveness` are configuration options related to how the cluster determines that a Triton Distributed Worker instance is "alive" and responsive.
+    liveness:
+      # `kubernetes.checks.liveness.enabled` when `true`, instructs the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.
+      enabled: # (default true)
+      # `kubernetes.checks.liveness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "alive").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.liveness.initialDelaySeconds` is the minimum wait time before the cluster begins to attempt to determine the health of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.liveness.periodSeconds` is the minimum period between attempts to determine the health of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.liveness.successThreshold` is the number of successful responses required to determine that a pod is healthy.
+      successThreshold: # (default 1)
+    # `kubernetes.checks.readiness` contains configuration options related to how the cluster determines that a Triton Distributed Worker instance is ready.
+    readiness:
+      # `kubernetes.checks.readiness.enabled` when `true`, instructs the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.
+      enabled: # (default true)
+      # `kubernetes.checks.readiness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "ready").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.readiness.initialDelaySeconds` is the minimum wait before the cluster begins to attempt to determine the readiness of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.readiness.periodSeconds` is the minimum period between attempts to determine the readiness of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.readiness.successThreshold` is the number of successful responses required to determine that a pod is ready.
+      successThreshold: # (default 1)
+  # `kubernetes.labels` is an optional set of labels to be applied to created Kubernetes objects.
+  # These labels can be used for association with a preexisting service object.
+  labels: [] # (optional)
+  # `kubernetes.partOf` is an optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.
+  partOf: # (default: triton-distributed)
+  # `kubernetes.tolerations` are tolerations applied to every pod deployed as part of this deployment.
+  # Template already includes `nvidia.com/gpu=present:NoSchedule` when `resources.gpu` is specified.
+  tolerations: [] # (optional)
+
+# `modelRepository` contains configuration options related to the model repository used by the Triton Distributed Worker to load model(s).
+modelRepository: # (optional)
+  # `modelRepository.path` is a local file-system path within the container to the model repository.
+  # When `persistentVolumeClaim` is specified, this is the path to which the PVC will be mounted.
+  path: # (default: /var/run/models)
+  # `modelRepository.volumeMounts` are persistent volumes (PV) to be mounted with the Triton Distributed Worker container.
+  volumeMounts: [] # (optional)
+  #   # `modelRepository.volumeMounts.name` is the name to associate the volume mount with. Volume mount names must be unique and cannot contain spaces or special characters.
+  # - name: # (required)
+  #   # `modelRepository.volumeMounts.path` is the file-system path relative to model repository's root path to which the volume will be mounted to.
+  #   # When not provided, the volume is mounted to the root of the repository.
+  #   # Overlapping mount paths can cause errors during container deployment.
+  #   path: # (optional)
+  #   # `modelRepository.volumeMounts.persistentVolumeclaim` is the name of the persistent volume claim (PVC) used to mount a folder containing the model(s) Triton will load.
+  #   persistentVolumeClaim: # (required)
+
+# `triton` contains configuration options related to the operation of Triton Distributed Worker.
+triton: # (required)
+  # `triton.componentName` is the name of the Triton Distributed Worker in the distributed deployment.
+  componentName: # (required)
+  # `triton.distributed` contains configuration options related to organization of Triton Distributed workflows.
+  distributed:
+    # `triton.distributed.requestPlane` contains configuration options related to connecting the Triton Distributed Worker to its Triton Distributed Request Plane.
+    requestPlane:
+      # `triton.distributed.requestPlane.serverKind` is the "kind" of server providing Triton Distributed Request Plane functionality.
+      # Supported options: `nats-io`.
+      serverKind: # (default nats-io)
+      # `triton.distributed.requestPlane.serviceName` is the name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.
+      # The service name will be used to resolve the network communication addressing within the cluster (example: <serviceName>.svc.cluster.local).
+      serviceName: # (default triton-distributed_request-plane)
+      # `triton.distributed.requestPlane.servicePort` is the networking port to be used to interact with the Triton Distributed Request Plane.
+      servicePort: # (default 30222)
+  # `triton.instance` are optional configuration options related to the number of Triton Distributed Worker pods are deployed.
+  instance:
+    # `triton.instance.count` is the number of worker instances (whole model) to be deployed as part of this helm chart.
+    count: # (default 1)
+    # `triton.instance.parallelism` contains optional configuration options related to how work for a single model is spread across multiple pods.
+    # When the product of `pipeline`*`tensor` is greater than 1, multiple pods will be deployed as a single logical worker.
+    parallelism:
+      # `triton.instance.parallelism.pipeline` specifies the level of pipeline parallelism used by the model hosted by the Triton Distributed Worker.
+      # Pipeline parallelism involves sharding the model (vertically) into chunks, where each chunk comprises a subset of layers that is executed on a separate device.
+      pipeline: # (default 1)
+      # `triton.instance.parallelism.tensor` specifies the level of tensor parallelism used by the model hosted by the Triton Distributed Worker.
+      # Tensor parallelism involves sharding (horizontally) individual layers of the model into smaller, independent blocks of computation that can be executed on different devices.
+      tensor: # (default 1)
+  # `triton.logging` contains logging configuration options specific to Triton Distributed Worker.
+  logging: # (optional)
+    # `triton.logging.useIso8601` when `true`, instructs Triton Distributed Worker logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.
+    useIso8601: # (default: false)
+    # `triton.logging.verbose` when `true`, instructs Triton Distributed Worker uses verbose logging; otherwise standard logging is used.
+    verbose: # (default: false)
+  # `triton.ports` contains configuration options for the management of the Triton Distributed Worker exposed.
+  ports: # (optional)
+    # `triton.ports.data` is the container port exposed to enable Triton Distributed Worker data-plane operations.
+    data: # (default 9346)
+    # `triton.ports.health` is the container port exposed to enable Triton Distributed Worker Kubernetes health reporting.
+    health: # (default 8000)
+    # `triton.ports.metrics` is the container port exposed to enable Triton Distributed Worker metrics reporting.
+    metrics: # (default 9347)
+    # `triton.ports.request` is the container port exposed to enable Triton Distributed Worker request-plane operations.
+    request: # (default 9345)
+  # `triton.resources` contains configuration options related to the resources assigned to Triton Distributed Worker and loaded model(s).
+  resources: # (optional)
+    # `triton.resources.cpu` is the number of logical CPU cores required by the Triton Distributed Worker and loaded model(s).
+    cpu: # (default: 4)
+    # `triton.resources.ephemeral` is the ephemeral storage (aka local disk usage) allowance.
+    # Ephemeral storage MUST include any shared memory allocated to Triton Distributed Worker.
+    # Value must be provided in Kubernetes' unit notation.
+    ephemeral: # (default: 1Gi)
+    # `triton.resources.gpu` contains configuration options related GPU resources to be assigned to the Triton Distributed Worker and loaded model(s).
+    gpu: # (optional)
+      # `triton.resources.gpu.count` specifies the number of GPUs required by the Triton Distributed Worker and loaded model(s).
+      count: # (default: 1)
+      # `triton.resources.gpu.product` defines list of the supported GPUs to which Triton Distributed Worker instance(s) can be deployed.
+      # Value must match the node's `.metadata.labels.nvidia.com/gpu.product` label provided by the NVIDIA GPU Discovery Service.
+      # Run 'kubectl get nodes' to find node names.
+      # Run 'kubectl describe node <node_name>' to inspect a node's labels.
+      product: [] # (optional)
+    # `triton.resources.memory` specifies the amount of CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s).
+    # Value must be provided in Kubernetes' unit notation.
+    memory: # (default: 16Gi)
+    # `triton.resources.sharedMemory` specifies about amount of shared CPU visible (aka host) memory available the Triton Distributed Worker and loaded model(s).
+    # Value must be provided in Kubernetes' unit notation.
+    sharedMemory: # (default: 512Mi)


### PR DESCRIPTION
This change adds the initial version of the vLLM worker Helm chart.

This is NOT the final values schema.

Includes schema validation and embedded chart scripting to enable default values.

No tests included because we have not yet agreed on the best mechanism to validate Helm charts.

DLIS-7810
