### PR TITLE
deploy: add initial openai api-server chart

### DIFF
--- a/deploy/Kubernetes/api-server/charts/OpenAI/Chart.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/Chart.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: 1.0.0
+description: Triton Distributed OpenAI API Server
+icon: https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-d@2x.png
+name: triton-distributed_api-server-openai
+version: 1.0.0

--- a/deploy/Kubernetes/api-server/charts/OpenAI/templates/_helpers.tpl
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Annotation Groups
+{{- define "triton.annotations.default" }}
+triton-distributed: "{{ .Release.Name }}.{{ .Chart.AppVersion | default "0.0" }}"
+{{-   with .Values.kubernetes }}
+{{-     with .annotations }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{- end -}}
+
+{{- define "triton.annotations.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+{{-   template "triton.annotations.default" . }}
+{{- end -}}
+
+# Label Groups
+{{- define "triton.labels.default" }}
+{{-   template "triton.label.appInstance" . }}
+{{-   template "triton.label.appName" . }}
+{{-   template "triton.label.appPartOf" . }}
+{{-   template "triton.label.appVersion" . }}
+{{- end -}}
+
+{{- define "triton.labels.chart" }}
+{{-   template "triton.labels.default" . }}
+{{-   template "triton.label.appManagedBy" . }}
+{{-   template "triton.label.chart" . }}
+{{-   with .Values.kubernetes }}
+{{-     with .labels }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{-   template "triton.label.release" . }}
+{{- end -}}
+
+# Label Values
+{{- define "triton.label.appInstance" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "triton.label.appManagedBy" }}
+{{-   $service_name := "triton-distributed" }}
+{{-   with .Release.Service }}
+{{-     $service_name = . }}
+{{-   end }}
+app.kubernetes.io/managed-by: {{ $service_name }}
+{{- end }}
+
+{{- define "triton.label.appName" }}
+app.kubernetes.io/name: {{ required "Property '.triton.componentName' is required." .Values.triton.componentName }}
+{{- end }}
+
+{{- define "triton.label.appPartOf" }}
+{{-   $part_of := "triton-distributed" }}
+{{-   with .Values.kubernetes }}
+{{-     with .partOf }}
+{{-       $part_of = . }}
+{{-     end }}
+{{-   end }}
+app.kubernetes.io/part-of: {{ $part_of }}
+{{- end }}
+
+{{- define "triton.label.appVersion" }}
+app.kubernetes.io/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+helm.sh/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.release" }}
+release: "{{ .Chart.Name }}_v{{ .Chart.Version | default "0.0" }}"
+{{- end }}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-deployment.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-deployment.yaml
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $triton_image_name := "" }}
+{{- with $.Values.image }}
+{{-   $triton_image_name = required "Property '.image.name' is required." .name }}
+{{- else }}
+{{-   fail "Property '.image' is required." }}
+{{- end }}
+{{- $component_name := "" }}
+{{- $instance_count := 1 }}
+{{- $k8s_liveness_delay := 10 }}
+{{- $k8s_liveness_enabled := true }}
+{{- $k8s_liveness_fail := 15 }}
+{{- $k8s_liveness_period := 2 }}
+{{- $k8s_liveness_success := 1 }}
+{{- $k8s_readiness_delay := 10 }}
+{{- $k8s_readiness_enabled := true }}
+{{- $k8s_readiness_fail := 15 }}
+{{- $k8s_readiness_period := 2 }}
+{{- $k8s_readiness_success := 1 }}
+{{- $request_plane_kind := "nats-io" }}
+{{- $request_plane_name := "triton-distributed_request-plane" }}
+{{- $request_plane_port := 30222 }}
+{{- $port_api := 443 }}
+{{- $port_health := 8000 }}
+{{- $port_metrics := 9347 }}
+{{- $port_request := 9345 }}
+{{- $triton_cpu := 4 }}
+{{- $triton_ephemeral := "1Gi" }}
+{{- $triton_logging_iso8601 := 0 }}
+{{- $triton_logging_verbose := 0 }}
+{{- $triton_memory := "16Gi" }}
+{{- with $.Values.kubernetes }}
+{{-   with .checks }}
+{{-     with .liveness }}
+{{-       $k8s_liveness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_liveness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_liveness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_liveness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_liveness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-     with .readiness }}
+{{-       $k8s_readiness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_readiness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_readiness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_readiness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_readiness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.triton }}
+{{-   $component_name = required "Property '.triton.componentName' is required." .componentName }}
+{{-   with .distributed }}
+{{-     with .manifold }}
+{{-       with .serverKind }}
+{{-         $request_plane_kind = . }}
+{{-       end }}
+{{-       with .serviceName }}
+{{-         $request_plane_name = . }}
+{{-       end }}
+{{-       with .servicePort }}
+{{-         $request_plane_port = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{-   with .instance }}
+{{-     with .count }}
+{{-       $instance_count = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .logging }}
+{{-     if .useIso8601 }}
+{{-       $triton_logging_iso8601 = 1 }}
+{{-     end }}
+{{-     if .verbose }}
+{{-       $triton_logging_verbose = 1 }}
+{{-     end }}
+{{-   end }}
+{{-   with .ports }}
+{{-     with .api }}
+{{-       $port_api = (int .) }}
+{{-     end }}
+{{-     with .health }}
+{{-       $port_health = (int .) }}
+{{-     end }}
+{{-     with .metrics }}
+{{-       $port_metrics = (int .) }}
+{{-     end }}
+{{-     with .request }}
+{{-       $port_request = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .resources }}
+{{-     with .cpu }}
+{{-       $triton_cpu = (int .) }}
+{{-     end }}
+{{-     with .ephemeral }}
+{{-       $triton_ephemeral = . }}
+{{-     end }}
+{{-     with .memory }}
+{{-       $triton_memory = . }}
+{{-     end }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  annotations:
+{{- with $ }}
+{{-   include "triton.annotations.chart" . | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: api-server
+{{- with $ }}
+{{-   include "triton.labels.chart" . | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}
+      app.kubernetes.io/component: api-server
+  replicas: {{ $instance_count }}
+  template:
+    metadata:
+      annotations:
+{{- with $ }}
+{{-   include "triton.annotations.chart" . | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ $.Release.Name }}
+        app.kubernetes.io/component: api-server
+{{- with $ }}
+{{-   include "triton.labels.chart" . | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: server
+        command:
+{{- if $triton_logging_iso8601 }}
+        - --iso8601
+{{- end}}
+{{- if $triton_logging_verbose }}
+        - --verbose
+{{- end }}
+        env:
+        - name: TRITON_COMPONENT_NAME:
+          value: {{ $component_name }}
+        - name: TRITON_REQUEST_PLANE_KIND
+          value: {{ $request_plane_kind }}
+        - name: TRITON_REQUEST_PLANE_NAME
+          value: {{ $request_plane_name }}
+        - name: TRITON_REQUEST_PLANE_PORT
+          value: {{ $request_plane_port }}
+{{- if ne $port_api 443 }}
+        - name: TRITON_PORT_API
+          value: {{ $port_api }}
+{{- end }}
+{{- if ne $port_health 8000 }}
+        - name: TRITON_PORT_HEALTH
+          value: {{ $port_health }}
+{{- end }}
+{{- if ne $port_metrics 9347 }}
+        - name: TRITON_PORT_METRICS
+          value: {{ $port_metrics }}
+{{- end }}
+{{- if ne $port_request 9345 }}
+        - name: TRITON_PORT_REQUEST
+          value: {{ $port_request }}
+{{- end }}
+        image: {{ $triton_image_name }}
+        imagePullPolicy: IfNotPresent
+{{- if $k8s_liveness_enabled }}
+        livenessProbe:
+          failureThreshold: {{ $k8s_liveness_fail }}
+          httpGet:
+            path: /v2/health/live
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_liveness_delay }}
+          periodSeconds: {{ $k8s_liveness_period }}
+          successThreshold: {{ $k8s_liveness_success }}
+{{- end }}
+        ports:
+        - containerPort: {{ $port_health }}
+          name: health
+        - containerPort: {{ $port_request }}
+          name: request
+        - containerPort: {{ $port_api }}
+          name: api
+        - containerPort: {{ $port_metrics }}
+          name: metrics
+{{- if $k8s_readiness_enabled }}
+        readinessProbe:
+          failureThreshold: {{ $k8s_readiness_fail }}
+          httpGet:
+            path: /v2/health/ready
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_readiness_delay }}
+          periodSeconds: {{ $k8s_readiness_period }}
+          successThreshold: {{ $k8s_readiness_success }}
+{{- end }}
+        resources:
+          limits:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+          requests:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- with $.Values.image }}
+{{-   with .pullSecrets }}
+{{-     if len . }}
+      imagePullSecrets:
+{{        toYaml . | indent 6 }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+{{- with $.Values.kubernetes }}
+{{-   with .tolerations }}
+      tolerations:
+{{      toYaml . | indent 6 }}
+{{-   end }}
+{{- end }}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-service.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-service.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $service_name := "" }}
+{{- $service_port := 30345 }}
+{{- $service_type := "ClusterIP" }}
+{{- with $.Values.triton }}
+{{-   with .service }}
+{{-     $service_name = required "Property '.triton.service.name' is required" .name }}
+{{-     with .port }}
+{{-       if lt . 30000 }}
+{{-         fail (printf "Property '.triton.service.port' cannot be less than `30000`, but is `%d`." .) }}
+{{-       end }}
+{{-       if gt . 32767 }}
+{{-         fail (printf "Property '.triton.service.port' cannot be greater than `32767`, but is `%d`." .) }}
+{{-       end }}
+{{-       $service_port = (int .) }}
+{{-     end }}
+{{-     with .type }}
+{{-       $service_type = . }}
+{{-     end }}
+{{-   else }}
+{{-     fail "Property '.service' is required." }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ $service_name | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+  annotations:
+{{- with $ }}
+{{-   include "triton.annotations.chart" . | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: network-service
+{{- with $ }}
+{{-   include "triton.labels.chart" . | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: external
+    port: {{ $service_port }}
+    targetPort: api
+  selector:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: api-server
+  type: {{ $service_type }}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/values.schema.json
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/values.schema.json
@@ -1,0 +1,448 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "copyright": [
+    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.",
+    "SPDX-License-Identifier: Apache-2.0",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License.",
+    "You may obtain a copy of the License at",
+    "http://www.apache.org/licenses/LICENSE-2.0",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
+  "properties": {
+    "image": {
+      "description": "Configuration options related to the Triton Distributed API Server container image.",
+      "properties": {
+        "pullSecrets": {
+          "description": "Optional list of pull secrets to be used when downloading the Triton Distributed API Server container image.",
+          "oneOf": [
+            {
+              "items": [
+                {
+                  "properties": {
+                    "name": {
+                      "$ref": "#/$defs/kubernetes_label",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "name": {
+          "description": "Name of the container image containing the version of Triton Distributed API Server container image to be used.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "kubernetes": {
+      "description": "Configurations option related to the Kubernetes objects created by the chart.",
+      "properties": {
+        "annotations": {
+          "description": "Optional set of annotations to be applied to create Kubernetes objects.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "checks": {
+          "description": "Optional configuration options controlling how the cluster monitors the health of Triton Distributed API Server deployment(s).",
+          "properties": {
+            "liveness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed API Server instance is \"alive\" and responsive.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"alive\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster begins to attempt to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is healthy.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "readiness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed API Server instance is ready.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"ready\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster begins to attempt to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is ready.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+        "labels": {
+          "description": "Optional set of labels to be applied to created Kubernetes objects. These labels can be used for association with a preexisting service object.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "partOf": {
+          "description": "Optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.",
+          "oneOf": [
+            { "$ref": "#/$defs/kubernetes_label" },
+            { "type": "null" }
+          ]
+        },
+        "tolerations": {
+          "description": "Tolerations applied to every pod deployed as part of this deployment.",
+          "oneOf": [
+            {
+              "items": { "type": "object" },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "triton": {
+      "description": "Configuration options related to the operation of Triton Distributed API Server.",
+      "properties": {
+        "componentName": {
+          "description": "Name of the Triton Distributed API Server in the distributed deployment.",
+          "pattern": "^[a-z]([a-z0-9_\\-]{0,29}[a-z0-9])?$",
+          "type": "string"
+        },
+        "distributed": {
+          "description": "Configuration options related to organization of Triton Distributed workflows.",
+          "properties": {
+            "requestPlane": {
+              "description": "Configuration options related to connecting the Triton Distributed API Server to its Triton Distributed Request Plane.",
+              "properties": {
+                "serverKind": {
+                  "description": "Kind of server providing Triton Distributed Request Plane functionality. Supported options: 'nats-io'.",
+                  "oneOf": [
+                    {
+                      "pattern": "^nats-io$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "serviceName": {
+                  "description": "Name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.",
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
+                },
+                "servicePort": {
+                  "description": "Networking port to be used to interact with the Triton Distributed Request Plane.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "instance": {
+              "description": "Optional configuration options related to the number of Triton Distributed API Server pods are deployed.",
+              "properties": {
+                "count": {
+                  "description": "Number of API Server instances to be deployed as part of this helm chart.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "logging": {
+              "description": "Logging configuration options specific to Triton Distributed API Server.",
+              "properties": {
+                "useIso8601": {
+                  "description": "When `true` Triton Distributed API Server logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "verbose": {
+                  "description": "When `true` Triton Distributed API Server uses verbose logging; otherwise standard logging is used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "ports": {
+              "description": "Configuration options for the management of the Triton Distributed API Server exposed.",
+              "properties": {
+                "api": {
+                  "description": "Container port exposed to handle incoming network requests. his port will be exposed by the deployed Kubernetes service object.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "health": {
+                  "description": "Container port exposed to enable Triton Distributed API Server Kubernetes health reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "metrics": {
+                  "description": "Container port exposed to enable Triton Distributed API Server metrics reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "request": {
+                  "description": "Container port exposed to enable Triton Distributed API Server request-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "resources": {
+              "description": "Configuration options related to the resources assigned to Triton Distributed API Server.",
+              "properties": {
+                "cpu": {
+                  "description": "Number of logical CPU cores required by the Triton Distributed API Server.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "ephemeral": {
+                  "description": "Ephemeral storage (aka local disk usage) allowance. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type": "null" }
+                  ]
+                },
+                "memory": {
+                  "description": "Amount of CPU visible (aka host) memory available to the Triton Distributed API Server. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "service":
+            {
+              "description": "Configuration options related to the Kubernetes service object created for this API Server deployment. The Kubernetes service object provides indirection to deployed pod's `api` port.",
+              "properties": {
+                "name": {
+                  "description": "Name of the service used to interact with the service once deployed. Value must conform to Kubernetes label requirements. Commonly resolves as DNS entry `<name>.svc.cluster.local`.",
+                  "$ref": "#/$defs/kubernetes_label"
+                },
+                "port": {
+                  "description": "Network port the service exposes and redirects to the deployed API Server pod's `api` port.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/service_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "type": {
+                  "description": "Type of Kubernetes service to deploy. Supported values are `ClusterIP` or `LoadBalancer`. `NodePort` and `ExternalName` configurations are not supported.",
+                  "oneOf": [
+                    {
+                      "pattern": "^(ClusterIP|LoadBalancer)$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": [
+        "componentName",
+        "service"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "triton"
+  ],
+  "type": "object",
+  "$defs": {
+    "container_port": {
+      "maximum": 65535,
+      "minimum": 1025,
+      "type": "integer"
+    },
+    "kubernetes_label": {
+      "pattern": "^[a-z0-9]([a-z0-9_\\-\\/\\.]{0,61}[a-z0-9])?$",
+      "type": "string"
+    },
+    "kubernetes_units": {
+      "pattern": "^\\d+[GKMgkm]i$",
+      "type": "string"
+    },
+    "service_port": {
+      "maximum": 32767,
+      "minimum": 30000,
+      "type": "integer"
+    }
+  }
+}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/values.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/values.yaml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `image` contains configuration options related to the Triton Distributed API Server container image.
+image: # (required)
+  # `image.pullSecrets` is an optional list of pull secrets to be used when downloading the Triton Distributed API Server container image.
+  pullSecrets: # (optional)
+  # - name: pull-secret-name
+  # `image.name` is the name of the container image containing the version of Triton Distributed API Server container image to be used.
+  name: # (required)
+
+# `kubernetes` contains configurations option related to the Kubernetes objects created by the chart.
+kubernetes: # (optional)
+  # `kubernetes.annotations` is an optional set of annotations to be applied to create Kubernetes objects.
+  annotations: # (optional)
+  # `kubernetes.checks` are optional configuration options controlling how the cluster monitors the health of Triton Distributed API Server deployment(s).
+  checks:
+    # `kubernetes.checks.liveness` are configuration options related to how the cluster determines that a Triton Distributed API Server instance is "alive" and responsive.
+    liveness:
+      # `kubernetes.checks.liveness.enabled` when `true`, instructs the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.
+      enabled: # (default true)
+      # `kubernetes.checks.liveness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "alive").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.liveness.initialDelaySeconds` is the minimum wait time before the cluster begins to attempt to determine the health of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.liveness.periodSeconds` is the minimum period between attempts to determine the health of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.liveness.successThreshold` is the number of successful responses required to determine that a pod is healthy.
+      successThreshold: # (default 1)
+    # `kubernetes.checks.readiness` contains configuration options related to how the cluster determines that a Triton Distributed API Server instance is ready.
+    readiness:
+      # `kubernetes.checks.readiness.enabled` when `true`, instructs the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.
+      enabled: # (default true)
+      # `kubernetes.checks.readiness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "ready").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.readiness.initialDelaySeconds` is the minimum wait time before the cluster begins to attempt to determine the readiness of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.readiness.periodSeconds` is the minimum period between attempts to determine the readiness of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.readiness.successThreshold` is the number of successful responses required to determine that a pod is ready.
+      successThreshold: # (default 1)
+  # `kubernetes.labels` is an optional set of labels to be applied to created Kubernetes objects.
+  # These labels can be used for association with a preexisting service object.
+  labels: # (optional)
+  # Optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.
+  partOf: # (default: triton-distributed)
+  # `kubernetes.tolerations` are tolerations applied to every pod deployed as part of this deployment.
+  # Template already includes `nvidia.com/gpu=present:NoSchedule` when `resources.gpu` is specified.
+  tolerations: # (optional)
+
+# `triton` contains configuration options related to the operation of Triton Distributed API Server.
+triton: # (required)
+  # `triton.componentName` is the name of the Triton Distributed API Server in the distributed deployment.
+  componentName: # (required)
+  # `triton.distributed` contains configuration options related to organization of Triton Distributed workflows.
+  distributed:
+    # `triton.distributed.requestPlane` contains configuration options related to connecting the Triton Distributed API Server to its Triton Distributed Request Plane.
+    requestPlane:
+      # `triton.distributed.requestPlane.serverKind` is the "kind" of server providing Triton Distributed Request Plane functionality.
+      # Supported options: `nats-io`.
+      serverKind: # (default nats-io)
+      # `triton.distributed.requestPlane.serviceName` is the name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.
+      serviceName: # (default triton-distributed_request-plane)
+      # `triton.distributed.requestPlane.servicePort` is the networking port to be used to interact with the Triton Distributed Request Plane.
+      servicePort: # (default 30222)
+  # `triton.instance` are optional configuration options related to the number of Triton Distributed API Server pods are deployed.
+  instance:
+    # `triton.instance.count` is the number of API Server instances to be deployed as part of this helm chart.
+    count: # (default 1)
+  # `triton.logging` contains logging configuration options specific to Triton Distributed API Server.
+  logging: # (optional)
+    #`triton.logging.useIso8601` when `true`, instructs Triton Distributed API Server logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.
+    useIso8601: # (default: false)
+    # `triton.logging.verbose` when `true`, instructs Triton Distributed API Server uses verbose logging; otherwise standard logging is used.
+    verbose: # (default: false)
+  # `triton.ports` contains configuration options for the management of the Triton Distributed API Server exposed.
+  ports: # (optional)
+    # Container port exposed to handle API network traffic.
+    # This port will be exposed by the deployed Kubernetes service object.
+    api: # (default 443)
+    # `triton.ports.health` is the container port exposed to enable Triton Distributed API Server Kubernetes health reporting.
+    health: # (default 8000)
+    # `triton.ports.metrics` is the container port exposed to enable Triton Distributed API Server metrics reporting.
+    metrics: # (default 9347)
+    # `triton.ports.request` is the container port exposed to enable Triton Distributed API Server request-plane operations.
+    request: # (default 9345)
+  # `triton.resources` contains configuration options related to the resources assigned to Triton Distributed API Server.
+  resources: # (optional)
+    # `triton.resources.cpu` is the number of logical CPU cores  required by the Triton Distributed API Server.
+    cpu: # (default: 1)
+    # `triton.resources.ephemeral` is the ephemeral storage (aka local disk usage) allowance.
+    # Ephemeral storage (aka local disk usage) allowance.
+    # Value must be provided in Kubernetes' unit notation.
+    ephemeral: # (default: 1Gi)
+    # `triton.resources.memory` specifies the amount of CPU visible (aka host) memory available to the Triton Distributed API Server.
+    # Value must be provided in Kubernetes' unit notation.
+    memory: # (default: 4Gi)
+  # `triton.service` contains configuration options related to the Kubernetes service object created for this API Server deployment.
+  # The Kubernetes service object provides indirection to deployed pod's `api` port.
+  service: # (required)
+    # `triton.service.name` specifies the name of the service used to interact with the service once deployed.
+    # Value must conform to Kubernetes label requirements.
+    # Commonly resolves as DNS entry `<name>.svc.cluster.local`.
+    name: # (required)
+    # `triton.service.port` specifies the network port the service exposes and redirects to the deployed API Server pod's `api` port.
+    port: # (default 30345)
+    # `triton.service.type` specifies the type of Kubernetes service to deploy.
+    # Supported values are `ClusterIP` or `LoadBalancer`. `NodePort` and `ExternalName` configurations are not supported.
+    type: # (default ClusterIP)


### PR DESCRIPTION
This change adds the initial version of the OpenAPI API Server Helm chart.

This is NOT the final values schema.

Includes schema validation and embedded chart scripting to enable default values.

No tests included because we have not yet agreed on the best mechanism to validate Helm charts.

DLIS-7835

(request currently targets `jwyman/helm-chart-1` branch and not `main`)
