### PR TITLE
deploy: add initial helm chart validation test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
     exclude: .devcontainer
   - id: check-toml
   - id: check-yaml
+    exclude: ^deploy/Kubernetes/[^/]+/(charts|tests)/[^/]+/templates/
   - id: check-shebang-scripts-are-executable
   - id: end-of-file-fixer
     types_or: [c, c++, cuda, proto, textproto, java, python]

--- a/deploy/Kubernetes/.gitignore
+++ b/deploy/Kubernetes/.gitignore
@@ -1,0 +1,1 @@
+dev_values.yaml

--- a/deploy/Kubernetes/_build/common.ps1
+++ b/deploy/Kubernetes/_build/common.ps1
@@ -1,0 +1,515 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set-strictmode -version latest
+
+$global:_init_path = "${env:PWD}"
+$global:_git_branch = $null
+$global:_local = $null
+$global:_local_srcdir = $null
+$global:_repository_root = $null
+$global:_verbosity = $null
+
+$global:colors = @{
+  error = 'Red'
+  high = 'Cyan'
+  low = 'DarkGray'
+  medium = 'DarkBlue'
+  test = @{
+    failed = 'Red'
+    passed = 'Green'
+  }
+  title = 'Blue'
+  warning = 'Yellow'
+}
+
+function cleanup_after {
+  write-debug "<cleanup_after>"
+  $(reset_environment)
+}
+
+function configure_debug([bool] $enabled) {
+  write-debug "<configure_debug> enabled = '${enabled}'."
+
+  if ($enabled) {
+    # Notify user if any environment variables which could affect the build outcome are set prior to the build script running.
+    $overrides = @()
+
+    foreach ($entry in $(& get-childitem env:)) {
+      # We're only looking for environment variables which are used directly by the build scripts (starts with 'NVBUILD_`);
+      # and we're looking at environment variables which would indirectly affect the build scripts (i.e. `PATH`).
+      if ($entry.key.startswith('NVBUILD_')) {
+        # No reason to display values which are displayed when the build start, often time provided by the user.
+        if ($entry.key.endswith('_COMMAND') -or $entry.key.endswith('_VERBOSITY')) {
+          continue
+        }
+
+        $overrides += $entry
+      }
+    }
+
+    if ($overrides.count -gt 0) {
+      write-low ' Overriding environment variables:'
+      foreach ($entry in $overrides) {
+        write-low "  $($entry.key) = $($entry.Value)"
+      }
+    }
+  }
+}
+
+function create_directory([string] $path, [switch] $recreate) {
+  write-debug "<create_directory> path = '${path}'."
+  write-debug "<create_directory> recreate = ${recreate}"
+
+  $path_local = $(to_local_path $path)
+  write-debug "<ensure_directory> path_local = '${path_local}'."
+
+  if (test-path $path_local -pathType Container) {
+    if ($recreate) {
+      remove-item $path_local -Recurse | out-null
+      new-item $path_local -itemtype Directory | out-null
+    }
+  }
+  else {
+    new-item $path_local -itemtype Directory | out-null
+  }
+}
+
+function default_git_branch {
+  if (is_installed 'git') {
+    $value = "$(git branch --show-current)"
+  }
+  else {
+    $value = 'main'
+  }
+  write-debug "<default_git_branch> -> '${value}'."
+  return $value
+}
+
+function default_local_srcdir {
+  $value = $(& git rev-parse --show-toplevel)
+  write-debug "<default_local_srcdir> -> '${value}'."
+  return $value;
+}
+
+function default_verbosity {
+  $value = 'MINIMAL'
+  write-debug "<default_verbosity> -> '${value}'."
+  return $value
+}
+
+function env_get_git_branch {
+  $value = $env:NVBUILD_GIT_BRANCH
+  write-debug "<env_get_git_branch> -> '${value}'."
+  return $value
+}
+
+function env_get_local_srcdir {
+  $value = $env:NVBUILD_LOCAL_SRCDIR
+  write-debug "<env_get_local_srcdir> -> '${value}'."
+  return $value
+}
+
+function env_get_verbosity {
+  $value = $env:NVBUILD_VERBOSITY
+  write-debug "<env_get_verbosity> -> '${value}'."
+  return $value
+}
+
+function env_set_git_branch([string] $value) {
+  if ($null -eq $env:NVBUILD_NOSET) {
+    write-debug "<env_set_git_branch> value: '${value}'."
+    $env:NVBUILD_GIT_BRANCH = $value
+  }
+}
+
+function env_set_local_srcdir([string] $value) {
+  if ($null -eq $env:NVBUILD_NOSET) {
+    write-debug "<env_set_local_srcdir> value: '${value}'."
+    $env:NVBUILD_LOCAL_SRCDIR = $value
+  }
+}
+
+function env_set_verbosity([string] $value) {
+  if ($null -eq $env:NVBUILD_NOSET) {
+    write-debug "<env_set_verbosity> value: '${value}'."
+    $env:NVBUILD_VERBOSITY = $value
+  }
+}
+
+function fatal_exit([string] $message) {
+  write-error "fatal: ${message}"
+  exit 1
+}
+
+function get_git_branch {
+  if ($null -eq $global:_git_branch) {
+    $value = $(env_set_git_branch)
+    if ($null -ne $value) {
+      set_git_branch $value
+    }
+    else {
+      set_git_branch $(default_git_branch)
+    }
+  }
+  write-debug "<get_git_branch> -> '${global:_git_branch}'."
+  return $global:_git_branch
+}
+
+function get_local_srcdir {
+  if ($null -eq $global:_local_srcdir) {
+    $value = $(env_get_local_srcdir)
+    if ($null -ne $value) {
+      set_local_srcdir $value
+    }
+    else {
+      set_local_srcdir $(default_local_srcdir)
+    }
+  }
+  write-debug "<get_local_srcdir> -> '${global:_local_srcdir}'."
+  return $global:_local_srcdir
+}
+
+function get_repository_root {
+  if ($null -eq $global:_repository_root) {
+    $global:_repository_root = $(& git rev-parse --show-toplevel)
+  }
+
+  write-debug "<get_repository_root> '${global:_repository_root}'."
+  return $global:_repository_root
+}
+
+function get_verbosity {
+  if ($null -eq $global:_verbosity) {
+    $value = $(env_get_verbosity)
+    if ($null -ne $value) {
+      set_verbosity $value
+    }
+    else {
+      set_verbosity $(default_verbosity)
+    }
+  }
+  write-debug "<get_verbosity> -> '${global:_verbosity}'."
+  return $global:_verbosity
+}
+
+function is_debug {
+  $value = $($null -ne $env:NVBUILD_DEBUG_TRACE)
+  write-debug "<is_debug> -> ${value}."
+  return $value
+}
+
+function is_empty([string] $value) {
+  return [System.String]::IsNullOrWhiteSpace($value)
+}
+
+function is_git_ignored([string] $path) {
+  $repo_root = $(get_repository_root)
+
+  if ($path.startswith($repo_root)) {
+    $path = $path.substring($repo_root.length)
+  }
+  if ($path.startswith('/')) {
+    $path = $path.substring(1)
+  }
+
+  $result = $(& git check-ignore $path)
+  return (0 -eq $result)
+}
+
+function is_installed([string] $command) {
+  write-debug "<is_installed> command = '${command}'."
+  $out = $null -ne $(get-command "${command}" -errorAction SilentlyContinue)
+  write-debug "<is_installed> -> ${out}."
+  return $out
+}
+
+
+function is_tty {
+  return -not(([System.Console]::IsOutputRedirected) -or ([System.Console]::IsErrorRedirected))
+}
+
+function is_verbosity_valid([string] $value) {
+  return (('NORMAL' -eq $value) -or ('MINIMAL' -eq $value) -or ('DETAILED' -eq $value))
+}
+
+function normalize_path([string] $path) {
+  write-debug "<normalize-path> path: '${path}'."
+  $out = $path
+  if ([System.IO.Path]::IsPathRooted($path)) {
+    $out = [System.IO.Path]::GetFullPath($path)
+  }
+  write-debug "<normalize-path> '${path}' -> '${out}'."
+  return $out
+}
+
+function read_content([string] $path, [switch] $lines, [switch] $bytes) {
+  if (is_empty $path -or ($lines -and $bytes)) {
+    write-error 'usage: read_content {path} [(-bytes|-lines)]' -category InvalidArgument
+    write-error ' {path} file system path of the file to read contents from.'
+    write-error ' -bytes when provided content is returned as an array of bytes. mutually exclusive with -lines.'
+    write-error ' -lines when provided content is returned as an array of strings. mutually exclusive with -bytes.'
+    write-error ' '
+    usage_exit 'read_content {path} [(-bytes|-lines)]'
+  }
+
+  write-debug "<read_content> path: '${path}'."
+  write-debug "<read_content> bytes: ${bytes}."
+  write-debug "<read_content> lines: ${lines}."
+
+  $path = $(to_local_path $path)
+
+  if ($bytes) {
+    return get-content -path $path -asbytestream -raw
+  }
+  if ($lines)
+  {
+    return get-content -path $path
+  }
+
+  return get-content -path $path -raw
+}
+
+function reset_environment {
+  write-debug "<reset_environment>"
+
+  $overrides = @()
+
+  foreach ($entry in $(& get-childitem env:)) {
+    # We're only looking for environment variables which are used directly by the build scripts (starts with 'NVBUILD_`);
+    # and we're looking at environment variables which would indirectly affect the build scripts (i.e. `PATH`).
+    if ($entry.key.startswith('NVBUILD_')) {
+      $overrides += $entry
+    }
+  }
+
+  if ($overrides.count -gt 0) {
+    foreach ($entry in $overrides) {
+      $expression = '$env:' + "$($entry.Key)" + ' = $null'
+      invoke-expression "${expression}"
+
+      if ("$($entry.Key)" -ne 'NVBUILD_NOSET') {
+        write-debug "<reset_environment> removed '$($entry.Key)'."
+      }
+    }
+  }
+}
+
+function run([string] $command) {
+  if ($null -eq $command) {
+    write-error 'usage: run {command}' -category InvalidArgument
+    write-error ' {command} is the command to execute.'
+    write-error ' '
+    usage_exit 'run {command}'
+  }
+
+  write-debug "<run> command = '${command}'."
+
+  if ('MINIMAL' -ne $(get_verbosity)) {
+    write-high "${command}"
+  }
+
+  invoke-expression "${command}" | out-default
+  $exit_code = $LASTEXITCODE
+
+  write-debug "<run> exit_code = ${exit_code}."
+
+  if ($exit_code -ne 0) {
+    write-error "fatal: Command ""${command}"" failed, returned ${exit_code}." -category fromStdErr
+    exit $exit_code
+  }
+}
+
+function set_git_branch([string] $value) {
+  write-debug "<set_git_branch> value = '${value}'."
+
+  $global:_git_branch = $value
+  env_set_git_branch $value
+}
+
+function set_local_srcdir([string] $value) {
+  write-debug "<set_local_srcdir> value: '${value}'."
+
+  $global:_local_srcdir = $value
+  env_set_local_srcdir $value
+}
+
+function set_verbosity([string] $value) {
+  write-debug "<set_verbosity> '${value}'."
+
+  if (-not(is_verbosity_valid $value)) {
+    throw "Invalid verbosity value '${value}'."
+  }
+
+  $global:_verbosity = $value
+  env_set_verbosity $value
+}
+
+function to_local_path([string] $path) {
+  write-debug "<to_local_path> path: '${path}'."
+
+  if ($null -eq $path) {
+    return $(get_local_srcdir)
+  }
+
+  $out = $path.trim()
+  $out = $out.trim('/','\')
+  $out = join-path $(get_local_srcdir) $out
+  $out = $(normalize_path $out)
+  return $out
+}
+
+function usage_exit([string] $message) {
+  write-error "usage: $message"
+  exit 254
+}
+
+function value_or_default([string] $value, [string] $default) {
+  if (($null -eq $value) -or ($value.Length -eq 0)) {
+    return $default
+  }
+
+  return $value
+}
+
+function write_content([string] $content, [string] $path, [switch] $overwrite) {
+  if (($null -eq $path) -or ($path.length -eq 0)) {
+    write-error 'usage: write_content {content} {path}'
+    write-error ' {content} is the content to be written to a file.'
+    write-error ' {path} is the path to file into which to write content.'
+    usage_exit 'write_content {content} {path}'
+  }
+
+  write-debug "<write_content> content = $($content.length) bytes."
+  write-debug "<write_content> path = '${path}'."
+  $path_local = $(to_local_path $path)
+  write-debug "<write-content> '${path_local}'."
+
+  if ($null -eq $content) {
+    $content = ''
+  }
+
+  if ($overwrite -and (test-path $path_local)) {
+    remove-item $path_local | out-null
+  }
+
+  $content | out-file $path_local
+}
+
+function __write([string] $value, [string] $color, [bool] $no_newline) {
+  if (is_tty) {
+    $opts = @{
+      NoNewline = $no_newline
+    }
+    if (($null -ne $color) -and ($color.length -gt 0)) {
+      $opts.ForegroundColor = $color
+    }
+    write-host $value @opts
+  }
+  else {
+    if (-not($no_newline)) {
+      $value = "${value}`n"
+    }
+    write-output $value
+  }
+}
+
+function write-detailed {
+  param([string] $value, [string] $color = $null, [switch] $no_newline)
+  if ('DETAILED' -eq $(get_verbosity)) {
+    __write $value $color $no_newline
+  }
+}
+
+function write-error([string] $value) {
+  $opts = @{
+    color = $global:colors.error
+    no_newline = $false
+  }
+  write-minimal $value @opts
+}
+
+function write-failed([string] $value) {
+  if (is_tty) {
+    write-normal '  Test:' -no_newline
+    write-normal ' [Failed]' $global:colors.test.failed -no_newline
+    write-normal " ${value}"
+  }
+  else {
+    write-output "  Test: [Failed] ${value}"
+  }
+}
+
+function write-high {
+  param([string] $value, [switch] $no_newline)
+  $opts = @{
+    color = $global:colors.high
+    no_newline = $no_newline
+  }
+  write-minimal $value @opts
+}
+
+function write-low {
+  param([string] $value, [switch] $no_newline)
+  $opts = @{
+    color      = $global:colors.low
+    no_newline = $no_newline
+  }
+  write-detailed $value @opts
+}
+
+function write-medium {
+  param([string] $value, [switch] $no_newline)
+  $opts = @{
+    color      = $global:colors.medium
+    no_newline = $no_newline
+  }
+  write-normal $value @opts
+}
+
+function write-minimal {
+  param([string] $value, [string] $color = $null, [switch] $no_newline)
+  __write $value $color $no_newline
+}
+
+function write-normal {
+  param([string] $value, [string] $color = $null, [switch] $no_newline)
+  if ('MINIMAL' -ne $(get_verbosity)) {
+    $opts = @{
+      color      = $color
+      no_newline = $no_newline
+    }
+    __write $value @opts
+  }
+}
+
+function write-passed([string] $value) {
+  if (is_tty) {
+    write-detailed '  Test:' -no_newline
+    write-detailed ' [Passed]' $global:colors.test.passed -no_newline
+    write-detailed " ${value}"
+  }
+  else {
+    write-output "  Test: [Passed] ${value}"
+  }
+}
+
+function write-title([string] $value) {
+  write-minimal $value $global:colors.title
+}
+
+function write-warning([string] $value) {
+  write-minimal $value $global:colors.warning
+}

--- a/deploy/Kubernetes/_build/helm-test.ps1
+++ b/deploy/Kubernetes/_build/helm-test.ps1
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set-strictmode -version latest
+
+. "$(& git rev-parse --show-toplevel)/deploy/Kubernetes/_build/common.ps1"
+
+function test_helm_chart([string] $chart_path, [string] $tests_path, [object[]] $test_set) {
+  write-debug "<test_helm_chart> chart_path = '${chart_path}'."
+  write-debug "<test_helm_chart> tests_path = '${tests_path}'."
+  write-debug "<test_helm_chart> test_set = [$($test_set.count)]"
+
+  $chart_path = to_local_path $chart_path
+  $tests_path = to_local_path $tests_path
+
+  push-location $chart_path
+
+  try {
+    $fail_count = 0
+    $pass_count = 0
+
+    foreach ($test in $test_set) {
+      $helm_command = 'helm template test -f ./values.yaml'
+      write-debug "<test_helm_chart> helm_command = '${helm_command}'."
+
+      # First add all values files to the command.
+      if (($null -ne $test.values) -and ($test.values.count -gt 0)) {
+        foreach ($value in $test.values) {
+          write-debug "<test_helm-chart> value = '${value}'."
+          $helm_command = "${helm_command} -f ${tests_path}/${value}"
+        }
+        write-debug "<test_helm_chart> helm_command = '${helm_command}'."
+      }
+
+      # Second add all --set options to the command.
+      if (($null -ne $test.options) -and $($test.options.count -gt 0)) {
+        foreach ($option in $test.options) {
+          write-debug "<test_helm_chart> option = '${option}'."
+          $helm_command = "${helm_command} --set `"${option}`""
+        }
+      }
+
+      $helm_command = "${helm_command} ."
+      write-debug "<test_helm_chart> helm_command = '${helm_command}'."
+
+      $captured = invoke-expression "${helm_command} 2>&1" | out-string
+      $exit_code = $LASTEXITCODE
+      write-debug "<test_helm_chart> expected = $($test.expected)."
+      write-debug "<test_helm_chart> actual = ${exit_code}."
+
+      $is_pass = $test.expected -eq $exit_code
+
+      if (-not $is_pass) {
+        write-low ">> Helm exited w/ ${exit_code}, test expected $($test.expected)."
+      }
+
+      if (($null -ne $test.matches) -and ($test.matches.count -gt 0)) {
+        foreach ($match in $test.matches) {
+          write-debug "<test_helm_chart> match = '${match}'."
+          $is_match = $captured -match $match
+          write-debug "<test_helm_chart> is_match = ${is_match}."
+
+          if (-not $is_match) {
+            write-low ">> Failed to match expected output: '${match}'."
+          }
+
+          $is_pass = $is_pass -and $is_match
+        }
+      }
+
+      if ($is_pass) {
+        $pass_count += 1
+        write-passed "$($test.name)"
+      }
+      else {
+        $fail_count += 1
+        write-failed "$($test.name)"
+      }
+    }
+  }
+  catch {
+    pop-location
+
+    throw $_
+  }
+
+  pop-location
+
+  if ($fail_count -gt 0) {
+    write-minimal "Failed: ${fail_count}, Passed: ${pass_count}, Total: $($tests.count)" 'Red'
+  }
+  else
+  {
+    write-minimal "Passed: ${pass_count}, Total: $($tests.count)" 'Green'
+  }
+}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/Chart.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/Chart.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: 1.0.0
+description: Triton Distributed OpenAI AP Server
+icon: https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-d@2x.png
+name: triton-distributed_api-server-openai
+version: 1.0.0

--- a/deploy/Kubernetes/api-server/charts/OpenAI/templates/_helpers.tpl
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Annotation Groups
+{{- define "triton.annotations.default" }}
+triton-distributed: "{{ .Release.Name }}.{{ .Chart.AppVersion | default "0.0" }}"
+{{-   with .Values.kubernetes }}
+{{-     with .annotations }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{- end -}}
+
+{{- define "triton.annotations.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+{{-   template "triton.annotations.default" . }}
+{{- end -}}
+
+# Label Groups
+{{- define "triton.labels.default" }}
+{{-   template "triton.label.appInstance" . }}
+{{-   template "triton.label.appName" . }}
+{{-   template "triton.label.appPartOf" . }}
+{{-   template "triton.label.appVersion" . }}
+{{- end -}}
+
+{{- define "triton.labels.chart" }}
+{{-   template "triton.labels.default" . }}
+{{-   template "triton.label.appManagedBy" . }}
+{{-   template "triton.label.chart" . }}
+{{-   with .Values.kubernetes }}
+{{-     with .labels }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{-   template "triton.label.release" . }}
+{{- end -}}
+
+# Label Values
+{{- define "triton.label.appInstance" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "triton.label.appManagedBy" }}
+{{-   $service_name := "triton-distributed" }}
+{{-   with .Release.Service }}
+{{-     $service_name = . }}
+{{-   end }}
+app.kubernetes.io/managed-by: {{ $service_name }}
+{{- end }}
+
+{{- define "triton.label.appName" }}
+app.kubernetes.io/name: {{ required "Property '.triton.componentName' is required." .Values.triton.componentName }}
+{{- end }}
+
+{{- define "triton.label.appPartOf" }}
+{{-   $part_of := "triton-distributed" }}
+{{-   with .Values.kubernetes }}
+{{-     with .partOf }}
+{{-       $part_of = . }}
+{{-     end }}
+{{-   end }}
+app.kubernetes.io/part-of: {{ $part_of }}
+{{- end }}
+
+{{- define "triton.label.appVersion" }}
+app.kubernetes.io/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+helm.sh/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.release" }}
+release: "{{ .Chart.Name }}_v{{ .Chart.Version | default "0.0" }}"
+{{- end }}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-deployment.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-deployment.yaml
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $triton_image_name := "" }}
+{{- with $.Values.image }}
+{{-   $triton_image_name = required "Property '.image.name' is required." .name }}
+{{- else }}
+{{-   fail "Property '.image' is required." }}
+{{- end }}
+{{- $component_name := "" }}
+{{- $instance_count := 1 }}
+{{- $k8s_liveness_delay := 10 }}
+{{- $k8s_liveness_enabled := true }}
+{{- $k8s_liveness_fail := 15 }}
+{{- $k8s_liveness_period := 2 }}
+{{- $k8s_liveness_success := 1 }}
+{{- $k8s_readiness_delay := 10 }}
+{{- $k8s_readiness_enabled := true }}
+{{- $k8s_readiness_fail := 15 }}
+{{- $k8s_readiness_period := 2 }}
+{{- $k8s_readiness_success := 1 }}
+{{- $request_plane_kind := "nats-io" }}
+{{- $request_plane_name := "triton-distributed_request-plane" }}
+{{- $request_plane_port := 30222 }}
+{{- $port_api := 443 }}
+{{- $port_health := 8000 }}
+{{- $port_metrics := 9347 }}
+{{- $port_request := 9345 }}
+{{- $triton_cpu := 4 }}
+{{- $triton_ephemeral := "1Gi" }}
+{{- $triton_logging_iso8601 := 0 }}
+{{- $triton_logging_verbose := 0 }}
+{{- $triton_memory := "16Gi" }}
+{{- with $.Values.kubernetes }}
+{{-   with .checks }}
+{{-     with .liveness }}
+{{-       $k8s_liveness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_liveness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_liveness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_liveness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_liveness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-     with .readiness }}
+{{-       $k8s_readiness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_readiness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_readiness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_readiness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_readiness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.triton }}
+{{-   $component_name = required "Property '.triton.componentName' is required." .componentName }}
+{{-   with .distributed }}
+{{-     with .manifold }}
+{{-       with .serverKind }}
+{{-         $request_plane_kind = . }}
+{{-       end }}
+{{-       with .serviceName }}
+{{-         $request_plane_name = . }}
+{{-       end }}
+{{-       with .servicePort }}
+{{-         $request_plane_port = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{-   with .instance }}
+{{-     with .count }}
+{{-       $instance_count = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .logging }}
+{{-     if .useIso8601 }}
+{{-       $triton_logging_iso8601 = 1 }}
+{{-     end }}
+{{-     if .verbose }}
+{{-       $triton_logging_verbose = 1 }}
+{{-     end }}
+{{-   end }}
+{{-   with .ports }}
+{{-     with .api }}
+{{-       $port_api = (int .) }}
+{{-     end }}
+{{-     with .health }}
+{{-       $port_health = (int .) }}
+{{-     end }}
+{{-     with .metrics }}
+{{-       $port_metrics = (int .) }}
+{{-     end }}
+{{-     with .request }}
+{{-       $port_request = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .resources }}
+{{-     with .cpu }}
+{{-       $triton_cpu = (int .) }}
+{{-     end }}
+{{-     with .ephemeral }}
+{{-       $triton_ephemeral = . }}
+{{-     end }}
+{{-     with .memory }}
+{{-       $triton_memory = . }}
+{{-     end }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  annotations:
+{{- with $ }}
+{{-   include "triton.annotations.chart" . | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: api-server
+{{- with $ }}
+{{-   include "triton.labels.chart" . | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}
+      app.kubernetes.io/component: api-server
+  replicas: {{ $instance_count }}
+  template:
+    metadata:
+      annotations:
+{{- with $ }}
+{{-   include "triton.annotations.chart" . | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ $.Release.Name }}
+        app.kubernetes.io/component: api-server
+{{- with $ }}
+{{-   include "triton.labels.chart" . | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: server
+        command:
+{{- if $triton_logging_iso8601 }}
+        - --iso8601
+{{- end}}
+{{- if $triton_logging_verbose }}
+        - --verbose
+{{- end }}
+        env:
+        - TRITON_COMPONENT_NAME: {{ $component_name }}
+        - TRITON_request_plane_kind: {{ $request_plane_kind }}
+        - TRITON_request_plane_name: {{ $request_plane_name }}
+        - TRITON_request_plane_port: {{ $request_plane_port }}
+{{- if ne $port_api 443 }}
+        - TRITON_PORT_API: {{ $port_api }}
+{{- end }}
+{{- if ne $port_health 8000 }}
+        - TRITON_PORT_HEALTH: {{ $port_health }}
+{{- end }}
+{{- if ne $port_metrics 9347 }}
+        - TRITON_PORT_METRICS: {{ $port_metrics }}
+{{- end }}
+{{- if ne $port_request 9345 }}
+        - TRITON_PORT_REQUEST: {{ $port_request }}
+{{- end }}
+        image: {{ $triton_image_name }}
+        imagePullPolicy: IfNotPresent
+{{- if $k8s_liveness_enabled }}
+        livenessProbe:
+          failureThreshold: {{ $k8s_liveness_fail }}
+          httpGet:
+            path: /v2/health/live
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_liveness_delay }}
+          periodSeconds: {{ $k8s_liveness_period }}
+          successThreshold: {{ $k8s_liveness_success }}
+{{- end }}
+        ports:
+        - containerPort: {{ $port_health }}
+          name: health
+        - containerPort: {{ $port_request }}
+          name: request
+        - containerPort: {{ $port_api }}
+          name: api
+        - containerPort: {{ $port_metrics }}
+          name: metrics
+{{- if $k8s_readiness_enabled }}
+        readinessProbe:
+          failureThreshold: {{ $k8s_readiness_fail }}
+          httpGet:
+            path: /v2/health/ready
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_readiness_delay }}
+          periodSeconds: {{ $k8s_readiness_period }}
+          successThreshold: {{ $k8s_readiness_success }}
+{{- end }}
+        resources:
+          limits:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+          requests:
+            cpu: {{ mul $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- with $.Values.image }}
+{{-   with .pullSecrets }}
+{{-     if len . }}
+      imagePullSecrets:
+{{        toYaml . | indent 6 }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+{{- with $.Values.kubernetes }}
+{{-   with .tolerations }}
+      tolerations:
+{{      toYaml . | indent 6 }}
+{{-   end }}
+{{- end }}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-service.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/templates/api-server-service.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $service_name := "" }}
+{{- $service_port := 30345 }}
+{{- $service_type := "ClusterIP" }}
+{{- with $.Values.triton }}
+{{-   with .service }}
+{{-     $service_name = required "Property '.triton.service.name' is required" .name }}
+{{-     with .port }}
+{{-       if lt . 30000 }}
+{{-         fail (printf "Property '.triton.service.port' cannot be less than `30000`, but is `%d`." .) }}
+{{-       end }}
+{{-       if gt . 32767 }}
+{{-         fail (printf "Property '.triton.service.port' cannot be greater than `32767`, but is `%d`." .) }}
+{{-       end }}
+{{-       $service_port = (int .) }}
+{{-     end }}
+{{-     with .type }}
+{{-       $service_type = . }}
+{{-     end }}
+{{-   else }}
+{{-     fail "Property '.service' is required." }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ $service_name | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+  annotations:
+{{- with $ }}
+{{-   include "triton.annotations.chart" . | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: network-service
+{{- with $ }}
+{{-   include "triton.labels.chart" . | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: external
+    port: {{ $service_port }}
+    targetPort: api
+  selector:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: api-server
+  type: {{ $service_type }}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/values.schema.json
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/values.schema.json
@@ -1,0 +1,448 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "copyright": [
+    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.",
+    "SPDX-License-Identifier: Apache-2.0",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License.",
+    "You may obtain a copy of the License at",
+    "http://www.apache.org/licenses/LICENSE-2.0",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
+  "properties": {
+    "image": {
+      "description": "Configuration options related to the Triton Distributed API Server container image.",
+      "properties": {
+        "pullSecrets": {
+          "description": "Optional list of pull secrets to be used when downloading the Triton Distributed API Server container image. Optional list of pull secrets to be used when downloading the Triton Distributed API Server container image.",
+          "oneOf": [
+            {
+              "items": [
+                {
+                  "properties": {
+                    "name": {
+                      "$ref": "#/$defs/kubernetes_label",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "name": {
+          "description": "Name of the container image containing the version of Triton Distributed API Server container image to be used.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "kubernetes": {
+      "description": "Configurations option related to the Kubernetes objects created by the chart.",
+      "properties": {
+        "annotations": {
+          "description": "Optional set of annotations to be applied to create Kubernetes objects.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "checks": {
+          "description": "Optional configuration options controlling how the cluster monitors the health of Triton Distributed API Server deployment(s).",
+          "properties": {
+            "liveness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed API Server instance is \"alive\" and responsive.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"alive\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster beings to attempt to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is healthy.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "readiness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed API Server instance is ready.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"ready\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster beings to attempt to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is ready.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+        "labels": {
+          "description": "Optional set of labels to be applied to created Kubernetes objects. These labels can be used for association with a preexisting service object.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "partOf": {
+          "description": "Optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.",
+          "oneOf": [
+            { "$ref": "#/$defs/kubernetes_label" },
+            { "type": "null" }
+          ]
+        },
+        "tolerations": {
+          "description": "Tolerations applied to every pod deployed as part of this deployment.",
+          "oneOf": [
+            {
+              "items": { "type": "object" },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "triton": {
+      "description": "Configuration options related to the operation of Triton Distributed API Server.",
+      "properties": {
+        "componentName": {
+          "description": "Name of the Triton Distributed API Server in the distributed deployment.",
+          "pattern": "^[a-z]([a-z09_\\-]{0,29}[a-z0-9])?$",
+          "type": "string"
+        },
+        "distributed": {
+          "description": "Configuration options related to organization of Triton Distributed workflows.",
+          "properties": {
+            "requestPlane": {
+              "description": "Configuration options related to connecting the Triton Distributed API Server to its Triton Distributed Request Plane.",
+              "properties": {
+                "serverKind": {
+                  "description": "Kind of server providing Triton Distributed Request Plane functionality. Supported options: 'nats-io'.",
+                  "oneOf": [
+                    {
+                      "pattern": "^nats-io$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "serviceName": {
+                  "description": "Name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.",
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
+                },
+                "servicePort": {
+                  "description": "Networking port to be used to interact with the Triton Distributed Request Plane.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "instance": {
+              "description": "Optional configuration options related to the number of Triton Distributed API Server pods are deployed.",
+              "properties": {
+                "count": {
+                  "description": "Number of API Server instances to be deployed as part of this helm chart.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "logging": {
+              "description": "Logging configuration options specific to Triton Distributed API Server.",
+              "properties": {
+                "useIso8601": {
+                  "description": "When `true` Triton Distributed API Server logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "verbose": {
+                  "description": "When `true` Triton Distributed API Server uses verbose logging; otherwise standard logging is used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "ports": {
+              "description": "Configuration options for the management of the Triton Distributed API Server exposed.",
+              "properties": {
+                "api": {
+                  "description": "Container port exposed to handle incoming network requests. his port will be exposed by the deployed Kubernetes service object.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "health": {
+                  "description": "Container port exposed to enable Triton Distributed API Server Kubernetes health reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "metrics": {
+                  "description": "Container port exposed to enable Triton Distributed API Server metrics reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "request": {
+                  "description": "Container port exposed to enable Triton Distributed API Server request-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "resources": {
+              "description": "Configuration options related to the resources assigned to Triton Distributed API Server.",
+              "properties": {
+                "cpu": {
+                  "description": "Number of logical CPU cores required by the Triton Distributed API Server.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "ephemeral": {
+                  "description": "Ephemeral storage (aka local disk usage) allowance. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type": "null" }
+                  ]
+                },
+                "memory": {
+                  "description": "Amount of CPU visible (aka host) memory available to the Triton Distributed API Server. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "service":
+            {
+              "description": "Configuration options related to the Kubernetes service object created for this API Server deployment. The Kubernetes service object provides indirection to deployed pod's `api` port.",
+              "properties": {
+                "name": {
+                  "description": "Name of the service used to interact with the service once deployed. Value must conform to Kubernetes label requirements. Commonly resolves as DNS entry `<name>.svc.cluster.local`.",
+                  "$ref": "#/$defs/kubernetes_label"
+                },
+                "port": {
+                  "description": "Network port the service exposes and redirects to the deployed API Server pod's `api` port.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/service_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "type": {
+                  "description": "Type of Kubernetes service to deploy. Supported values are `ClusterIP` or `LoadBalancer`. `NodePort` and `ExternalName` configurations are not supported.",
+                  "oneOf": [
+                    {
+                      "pattern": "^(ClusterIP|LoadBalancer)$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": [
+        "componentName",
+        "service"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "triton"
+  ],
+  "type": "object",
+  "$defs": {
+    "container_port": {
+      "maximum": 65535,
+      "minimum": 1025,
+      "type": "integer"
+    },
+    "kubernetes_label": {
+      "pattern": "^[a-z0-9]([a-z-09_\\-\\/\\.]{0,61}[a-z0-9])?$",
+      "type": "string"
+    },
+    "kubernetes_units": {
+      "pattern": "^\\d+[GKMgkm]i$",
+      "type": "string"
+    },
+    "service_port": {
+      "maximum": 32767,
+      "minimum": 30000,
+      "type": "integer"
+    }
+  }
+}

--- a/deploy/Kubernetes/api-server/charts/OpenAI/values.yaml
+++ b/deploy/Kubernetes/api-server/charts/OpenAI/values.yaml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `image` contains configuration options related to the Triton Distributed API Server container image.
+image: # (required)
+  # `image.pullSecrets` is an optional list of pull secrets to be used when downloading the Triton Distributed API Server container image.
+  pullSecrets: # (optional)
+  # - name: pull-secret-name
+  # `image.name` is the name of the container image containing the version of Triton Distributed API Server container image to be used.
+  name: # (required)
+
+# `kubernetes` contains configurations option related to the Kubernetes objects created by the chart.
+kubernetes: # (optional)
+  # `kubernetes.annotations` is an optional set of annotations to be applied to create Kubernetes objects.
+  annotations: # (optional)
+  # `kubernetes.checks` are optional configuration options controlling how the cluster monitors the health of Triton Distributed API Server deployment(s).
+  checks:
+    # `kubernetes.checks.liveness` are configuration options related to how the cluster determines that a Triton Distributed API Server instance is "alive" and responsive.
+    liveness:
+      # `kubernetes.checks.liveness.enabled` when `true`, instructs the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.
+      enabled: # (default true)
+      # `kubernetes.checks.liveness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "alive").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.liveness.initialDelaySeconds` is the minimum wait before the cluster beings to attempt to determine the health of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.liveness.periodSeconds` is the minimum period between attempts to determine the health of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.liveness.successThreshold` is the number of successful responses required to determine that a pod is healthy.
+      successThreshold: # (default 1)
+    # `kubernetes.checks.readiness` contains configuration options related to how the cluster determines that a Triton Distributed API Server instance is ready.
+    readiness:
+      # `kubernetes.checks.readiness.enabled` when `true`, instructs the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.
+      enabled: # (default true)
+      # `kubernetes.checks.readiness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "ready").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.readiness.initialDelaySeconds` is the minimum wait before the cluster beings to attempt to determine the readiness of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.readiness.periodSeconds` is the minimum period between attempts to determine the readiness of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.readiness.successThreshold` is the number of successful responses required to determine that a pod is ready.
+      successThreshold: # (default 1)
+  # `kubernetes.labels` is an optional set of labels to be applied to created Kubernetes objects.
+  # These labels can be used for association with a preexisting service object.
+  labels: # (optional)
+  # Optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.
+  partOf: # (default: triton-distributed)
+  # `kubernetes.tolerations` are tolerations applied to every pod deployed as part of this deployment.
+  # Template already includes `nvidia.com/gpu=present:NoSchedule` when `resources.gpu` is specified.
+  tolerations: # (optional)
+
+# `triton` contains configuration options related to the operation of Triton Distributed API Server.
+triton: # (required)
+  # `triton.componentName` is the name of the Triton Distributed API Server in the distributed deployment.
+  componentName: # (required)
+  # `triton.distributed` contains configuration options related to organization of Triton Distributed workflows.
+  distributed:
+    # `triton.distributed.requestPlane` contains configuration options related to connecting the Triton Distributed API Server to its Triton Distributed Request Plane.
+    requestPlane:
+      # `triton.distributed.requestPlane.serverKind` is the "kind" of server providing Triton Distributed Request Plane functionality.
+      # Supported options: `nats-io`.
+      serverKind: # (default nats-io)
+      # `triton.distributed.requestPlane.serviceName` is the name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.
+      serviceName: # (default triton-distributed_request-plane)
+      # `triton.distributed.requestPlane.servicePort` is the networking port to be used to interact with the Triton Distributed Request Plane.
+      servicePort: # (default 30222)
+  # `triton.instance` are optional configuration options related to the number of Triton Distributed API Server pods are deployed.
+  instance:
+    # `triton.instance.count` is the number of API Server instances to be deployed as part of this helm chart.
+    count: # (default 1)
+  # triton.logging` contains logging configuration options specific to Triton Distributed API Server.
+  logging: # (optional)
+    #`triton.logging.useIso8601` when `true`, instructs Triton Distributed API Server logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.
+    useIso8601: # (default: false)
+    # triton.logging.verbose` when `true`, instructs Triton Distributed API Server uses verbose logging; otherwise standard logging is used.
+    verbose: # (default: false)
+  # triton.ports` contains configuration options for the management of the Triton Distributed API Server exposed.
+  ports: # (optional)
+    # Container port exposed to handle API network traffic.
+    # This port will be exposed by the deployed Kubernetes service object.
+    api: # (default 443)
+    # triton.ports.health` is the container port exposed to enable Triton Distributed API Server Kubernetes health reporting.
+    health: # (default 8000)
+    # `triton.ports.metrics` is the container port exposed to enable Triton Distributed API Server metrics reporting.
+    metrics: # (default 9347)
+    # `triton.ports.request` is the container port exposed to enable Triton Distributed API Server request-plane operations.
+    request: # (default 9345)
+  # triton.resources` contains configuration options related to the resources assigned to Triton Distributed API Server.
+  resources: # (optional)
+    # `triton.resources.cpu` is the number of logical CPU cores  required by the Triton Distributed API Server.
+    cpu: # (default: 1)
+    # `triton.resources.ephemeral` is the ephemeral storage (aka local disk usage) allowance.
+    # Ephemeral storage (aka local disk usage) allowance.
+    # Value must be provided in Kubernetes' unit notation.
+    ephemeral: # (default: 1Gi)
+    # `triton.resources.memory` specifies the amount of CPU visible (aka host) memory available to the Triton Distributed API Server.
+    # Value must be provided in Kubernetes' unit notation.
+    memory: # (default: 4Gi)
+  # `triton.service` contains configuration options related to the Kubernetes service object created for this API Server deployment.
+  # The Kubernetes service object provides indirection to deployed pod's `api` port.
+  service: # (required)
+    # `triton.service.name` specifies the name of the service used to interact with the service once deployed.
+    # Value must conform to Kubernetes label requirements.
+    # Commonly resolves as DNS entry `<name>.svc.cluster.local`.
+    name: # (required)
+    # `triton.service.port` specifies the network port the service exposes and redirects to the deployed API Server pod's `api` port.
+    port: # (default 30345)
+    # `triton.service.port` specifies the type of Kubernetes service to deploy.
+    # Supported values are `ClusterIP` or `LoadBalancer`. `NodePort` and `ExternalName` configurations are not supported.
+    type: # (default ClusterIP)

--- a/deploy/Kubernetes/worker/charts/trtllm/Chart.yaml
+++ b/deploy/Kubernetes/worker/charts/trtllm/Chart.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: 1.0.0
+description: Triton Distributed Worker for TensorRT LMM
+icon: https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-d@2x.png
+name: triton-distributed_worker-vllm
+version: 1.0.0

--- a/deploy/Kubernetes/worker/charts/trtllm/Chart.yaml
+++ b/deploy/Kubernetes/worker/charts/trtllm/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 appVersion: 1.0.0
 description: Triton Distributed Worker for TensorRT LMM
 icon: https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-d@2x.png
-name: triton-distributed_worker-vllm
+name: triton-distributed_worker-trtllm
 version: 1.0.0

--- a/deploy/Kubernetes/worker/charts/trtllm/templates/_helpers.tpl
+++ b/deploy/Kubernetes/worker/charts/trtllm/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Annotation Groups
+{{- define "triton.annotations.default" }}
+triton-distributed: "{{ .Release.Name }}.{{ .Chart.AppVersion | default "0.0" }}"
+{{-   with .Values.kubernetes }}
+{{-     with .annotations }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{- end -}}
+
+{{- define "triton.annotations.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+{{-   template "triton.annotations.default" . }}
+{{- end -}}
+
+# Label Groups
+{{- define "triton.labels.default" }}
+{{-   template "triton.label.appInstance" . }}
+{{-   template "triton.label.appName" . }}
+{{-   template "triton.label.appPartOf" . }}
+{{-   template "triton.label.appVersion" . }}
+{{- end -}}
+
+{{- define "triton.labels.chart" }}
+{{-   template "triton.labels.default" . }}
+{{-   template "triton.label.appManagedBy" . }}
+{{-   template "triton.label.chart" . }}
+{{-   with .Values.kubernetes }}
+{{-     with .labels }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{-   template "triton.label.release" . }}
+{{- end -}}
+
+# Label Values
+{{- define "triton.label.appInstance" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "triton.label.appManagedBy" }}
+{{-   $service_name := "triton-distributed" }}
+{{-   with .Release.Service }}
+{{-     $service_name = . }}
+{{-   end }}
+app.kubernetes.io/managed-by: {{ $service_name }}
+{{- end }}
+
+{{- define "triton.label.appName" }}
+app.kubernetes.io/name: {{ required "Property '.triton.componentName' is required." .Values.triton.componentName }}
+{{- end }}
+
+{{- define "triton.label.appPartOf" }}
+{{-   $part_of := "triton-distributed" }}
+{{-   with .Values.kubernetes }}
+{{-     with .partOf }}
+{{-       $part_of = . }}
+{{-     end }}
+{{-   end }}
+app.kubernetes.io/part-of: {{ $part_of }}
+{{- end }}
+
+{{- define "triton.label.appVersion" }}
+app.kubernetes.io/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+helm.sh/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.release" }}
+release: "{{ .Chart.Name }}_v{{ .Chart.Version | default "0.0" }}"
+{{- end }}

--- a/deploy/Kubernetes/worker/charts/trtllm/templates/worker-deployment.yaml
+++ b/deploy/Kubernetes/worker/charts/trtllm/templates/worker-deployment.yaml
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $triton_image_name := "" }}
+{{- with $.Values.image }}
+{{-   $triton_image_name = required "Property '.image.name' is required." .name }}
+{{- else }}
+{{-   fail "Property '.image' is required." }}
+{{- end }}
+{{- $component_name := "" }}
+{{- $instance_count := 1 }}
+{{- $k8s_liveness_delay := 10 }}
+{{- $k8s_liveness_enabled := true }}
+{{- $k8s_liveness_fail := 15 }}
+{{- $k8s_liveness_period := 2 }}
+{{- $k8s_liveness_success := 1 }}
+{{- $k8s_readiness_delay := 10 }}
+{{- $k8s_readiness_enabled := true }}
+{{- $k8s_readiness_fail := 15 }}
+{{- $k8s_readiness_period := 2 }}
+{{- $k8s_readiness_success := 1 }}
+{{- $model_gen_enabled := true }}
+{{- $model_gen_host_enabled := false }}
+{{- $model_gen_host_path := "/triton/trtllm-cache" }}
+{{- $model_gen_path := "/var/run/trtllm" }}
+{{- $model_gen_quota := "96Gi" }}
+{{- $parallel_pipeline := 1 }}
+{{- $parallel_tensor := 1 }}
+{{- $parallel_world := 1 }}
+{{- $port_data := 9346 }}
+{{- $port_health := 8000 }}
+{{- $port_metrics := 9347 }}
+{{- $port_request := 9345 }}
+{{- $request_plane_kind := "nats-io" }}
+{{- $request_plane_name := "triton-distributed_request-plane" }}
+{{- $request_plane_port := 30222 }}
+{{- $triton_cpu := 4 }}
+{{- $triton_ephemeral := "1Gi" }}
+{{- $triton_gpu := 1 }}
+{{- $triton_logging_iso8601 := 0 }}
+{{- $triton_logging_verbose := 0 }}
+{{- $triton_memory := "16Gi" }}
+{{- $triton_shared := "512Mi" }}
+{{- with $.Values.kubernetes }}
+{{-   with .checks }}
+{{-     with .liveness }}
+{{-       $k8s_liveness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_liveness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_liveness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_liveness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_liveness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-     with .readiness }}
+{{-       $k8s_readiness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_readiness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_readiness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_readiness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_readiness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.modelRepository }}
+{{-   with .modelGeneration }}
+{{-     if eq .enabled false }}
+{{-       $model_gen_enabled = false }}
+{{-     end }}
+{{-     with .hostCache }}
+{{-       if eq .enabled true }}
+{{-         $model_gen_host_enabled = true }}
+{{-       end }}
+{{-       with .hostPath }}
+{{-         $model_gen_host_path = . }}
+{{-       end }}
+{{-     end }}
+{{-     with .path }}
+{{-       $model_gen_path = . }}
+{{-     end }}
+{{-     with .sizeLimit }}
+{{-       $model_gen_quota = . }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.triton }}
+{{-   $component_name = required "Property '.triton.componentName' is required." .componentName }}
+{{-   with .distributed }}
+{{-     with .manifold }}
+{{-       with .serverKind }}
+{{-         $request_plane_kind = . }}
+{{-       end }}
+{{-       with .serviceName }}
+{{-         $request_plane_name = . }}
+{{-       end }}
+{{-       with .servicePort }}
+{{-         $request_plane_port = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{-   with .instance }}
+{{-     with .count }}
+{{-       $instance_count = (int .) }}
+{{-     end }}
+{{-     with .parallelism }}
+{{-       with .pipeline }}
+{{-         $parallel_pipeline = (int .) }}
+{{-       end }}
+{{-       with .tensor }}
+{{-         $parallel_tensor = (int .) }}
+{{-       end }}
+{{-       $parallel_world = mul $parallel_pipeline $parallel_tensor }}
+{{-     end }}
+{{-   end }}
+{{-   with .logging }}
+{{-     if .useIso8601 }}
+{{-       $triton_logging_iso8601 = 1 }}
+{{-     end }}
+{{-     if .verbose }}
+{{-       $triton_logging_verbose = 1 }}
+{{-     end }}
+{{-   end }}
+{{-   with .ports }}
+{{-     with .data }}
+{{-       $port_data = (int .) }}
+{{-     end }}
+{{-     with .health }}
+{{-       $port_health = (int .) }}
+{{-     end }}
+{{-     with .metrics }}
+{{-       $port_metrics = (int .) }}
+{{-     end }}
+{{-     with .request }}
+{{-       $port_request = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .resources }}
+{{-     with .cpu }}
+{{-       $triton_cpu = (int .) }}
+{{-     end }}
+{{-     with .ephemeral }}
+{{-       $triton_ephemeral = . }}
+{{-     else }}
+{{-       if not $model_gen_host_enabled }}
+{{-          $triton_ephemeral = "97Gi" }}
+{{-       end }}
+{{-     end }}
+{{-     with .gpu }}
+{{-       $triton_gpu = (int .count) }}
+{{-     end }}
+{{-     with .memory }}
+{{-       $triton_memory = . }}
+{{-     end }}
+{{-     with .sharedMemory }}
+{{-       $triton_shared = . }}
+{{-     end }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+{{- $model_repo_path := "/var/run/models" }}
+{{- with $.Values.modelRepository }}
+{{-   with .path }}
+{{-     $model_repo_path = trimSuffix "/" . }}
+{{-   end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}
+  annotations:
+{{- include "triton.annotations.chart" . | indent 4 }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: worker
+{{- include "triton.labels.chart" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}
+      app.kubernetes.io/component: worker
+  replicas: {{ $instance_count }}
+  template:
+    metadata:
+      annotations:
+{{- include "triton.annotations.chart" . | indent 8 }}
+      labels:
+        app: {{ $.Release.Name }}
+        app.kubernetes.io/component: worker
+{{- include "triton.labels.chart" . | indent 8 }}
+    spec:
+{{- if ne $triton_gpu 0 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu
+                operator: Exists
+{{-   with $.Values.triton }}
+{{-     with .resources }}
+{{-       with .gpu }}
+{{-         with .product }}
+{{-           if len . }}
+              - key: nvidia.com/gpu.product
+                operator: In
+                values:
+{{            toYaml . | indent 16 }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      containers:
+      - name: triton
+        command:
+        - --model-repository={{ $model_repo_path }}
+{{- if $triton_logging_iso8601 }}
+        - --iso8601
+{{- end}}
+{{- if $triton_logging_verbose }}
+        - --verbose
+{{- end }}
+        env:
+        - TRITON_COMPONENT_NAME: {{ $component_name | quote }}
+{{- if gt $parallel_world 1 }}
+        - TRITON_LLM_PP: {{ $parallel_pipeline | quote }}
+        - TRITON_LLM_TP: {{ $parallel_tensor | quote }}
+{{- end }}
+        - TRITON_REQUEST_PLANE_KIND: {{ $request_plane_kind | quote }}
+        - TRITON_REQUEST_PLANE_NAME: {{ $request_plane_name | quote }}
+        - TRITON_REQUEST_PLANE_PORT: {{ $request_plane_port | quote }}
+        - TRITON_MODEL_REPOSITORY: {{ $model_repo_path | quote }}
+{{- if $model_gen_enabled }}
+        - TRITON_MODEL_GENERATION_PATH: {{ $model_gen_path | quote }}
+        - TRITON_MODEL_GENERATION_QUOTA: {{ $model_gen_quota | quote }}
+{{-   with $.Values.modelRepository }}
+{{-     with .modelGeneration }}
+{{-       with .options }}
+{{-         with .convertCheckpoint }}
+{{-           if len . }}
+{{-             $count := 0 }}
+{{-             range $i, $v := . }}
+        - TRITON_MODEL_GEN_CCO_{{ $i }}: {{ $v | quote }}
+{{-               $count = add 1 $count }}
+{{-             end }}
+        - TRITON_MODEL_GEN_CCO_COUNT: {{ $count | quote }}
+{{-           end }}
+{{-         end }}
+{{-         with .trtllmBuild }}
+{{-           if len . }}
+{{-             $count := 0 }}
+{{-             range $i, $v := . }}
+        - TRITON_MODEL_GEN_BLD_{{ $i }}: {{ $v | quote }}
+{{-               $count = add 1 $count }}
+{{-             end }}
+        - TRITON_MODEL_GEN_BLD_COUNT: {{ $count | quote }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- if ne $port_data 9346 }}
+        - TRITON_PORT_DATA: {{ $port_data }}
+{{- end }}
+{{- if ne $port_health 8000 }}
+        - TRITON_PORT_HEALTH: {{ $port_health }}
+{{- end }}
+{{- if ne $port_metrics 9347 }}
+        - TRITON_PORT_METRICS: {{ $port_metrics }}
+{{- end }}
+{{- if ne $port_request 9345 }}
+        - TRITON_PORT_REQUEST: {{ $port_request }}
+{{- end }}
+        image: {{ $triton_image_name }}
+        imagePullPolicy: IfNotPresent
+{{- if $k8s_liveness_enabled }}
+        livenessProbe:
+          failureThreshold: {{ $k8s_liveness_fail }}
+          httpGet:
+            path: /v2/health/live
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_liveness_delay }}
+          periodSeconds: {{ $k8s_liveness_period }}
+          successThreshold: {{ $k8s_liveness_success }}
+{{- end }}
+        ports:
+        - containerPort: {{ $port_health }}
+          name: health
+        - containerPort: {{ $port_request }}
+          name: request
+        - containerPort: {{ $port_data }}
+          name: data
+        - containerPort: {{ $port_metrics }}
+          name: metrics
+{{- if $k8s_readiness_enabled }}
+        readinessProbe:
+          failureThreshold: {{ $k8s_readiness_fail }}
+          httpGet:
+            path: /v2/health/ready
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_readiness_delay }}
+          periodSeconds: {{ $k8s_readiness_period }}
+          successThreshold: {{ $k8s_readiness_success }}
+{{- end }}
+        resources:
+          limits:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- if gt $triton_gpu 0 }}
+            nvidia.com/gpu: {{ $triton_gpu }}
+{{- end }}
+          requests:
+            cpu: {{ mul $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- if gt $triton_gpu 0 }}
+            nvidia.com/gpu: {{ $triton_gpu }}
+{{- end }}
+        volumeMounts:
+{{- with $.Values.modelRepository }}
+{{-   with .volumeMounts }}
+{{-     range . }}
+{{-       $mount_path := $model_repo_path }}
+{{-       $volume_name := required "Property '.modelRepository.volumeMounts[*].name' is required." .name }}
+{{-       if eq "shared-memory" $volume_name }}
+{{-         fail "Property '.modelRepository.volumeMounts[*].name' cannot be `shared-memory` because it is a reserved name." }}
+{{-       end }}
+{{-       if eq "model-host-cache" $volume_name }}
+{{-         fail "Property '.modelRepository.volumeMounts[*].name' cannot be `model-host-cache` because it is a reserved name." }}
+{{-       end }}
+{{-       with .path }}
+{{-         $mount_path = printf "%s/%s" $model_repo_path (trimPrefix "/" .) }}
+{{-         if regexMatch "/\\.\\./?" $mount_path }}
+{{-           fail (printf "Value of property `.modelRepository.volumeMounts[*].path' `%s` is illegal because `%s` is not a sub-directory of `%s`." . (clean $mount_path) $model_repo_path) }}
+{{-         end }}
+{{-       end }}
+        - mountPath: {{ $mount_path }}
+          name: {{ $volume_name  }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- if and $model_gen_enabled $model_gen_host_enabled }}
+        - mountPath: {{ $model_gen_path }}
+          name: model-host-cache
+{{- end }}
+        - mountPath: /dev/shm
+          name: shared-memory
+{{- with $.Values.image }}
+{{-   with .pullSecrets }}
+{{-     if len . }}
+      imagePullSecrets:
+{{        toYaml . | indent 6 }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      tolerations:
+{{- with $.Values.triton }}
+{{-   with .resources }}
+{{-     with .gpu }}
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.kubernetes }}
+{{-   with .tolerations }}
+{{      toYaml . | indent 6 }}
+{{-   end }}
+{{- end }}
+      volumes:
+{{- with $.Values.modelRepository }}
+{{-   with .volumeMounts }}
+{{-     range . }}
+      - name: {{ required "Property '.modelRepository.volumeMounts.name' is required." .name  }}
+        persistentVolumeClaim:
+          claimName: {{ required "Property '.modelRepository.volumeMounts.persistentVolumeClaim' is required." .persistentVolumeClaim }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- if and $model_gen_enabled $model_gen_host_enabled }}
+      - name: model-host-cache
+        hostPath:
+          path: {{ $model_gen_host_path }}
+          type: DirectoryOrCreate
+{{- else }}
+      - name: model-host-cache
+        emptyDir:
+          sizeLimit: {{ $model_gen_quota }}
+{{- end }}
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ $triton_shared }}

--- a/deploy/Kubernetes/worker/charts/trtllm/templates/worker-deployment.yaml
+++ b/deploy/Kubernetes/worker/charts/trtllm/templates/worker-deployment.yaml
@@ -47,7 +47,7 @@
 {{- $request_plane_name := "triton-distributed_request-plane" }}
 {{- $request_plane_port := 30222 }}
 {{- $triton_cpu := 4 }}
-{{- $triton_ephemeral := "1Gi" }}
+{{- $triton_ephemeral := "98Gi" }}
 {{- $triton_gpu := 1 }}
 {{- $triton_logging_iso8601 := 0 }}
 {{- $triton_logging_verbose := 0 }}
@@ -166,8 +166,15 @@
 {{-     with .ephemeral }}
 {{-       $triton_ephemeral = . }}
 {{-     else }}
-{{-       if not $model_gen_host_enabled }}
-{{-          $triton_ephemeral = "97Gi" }}
+{{-       if $model_gen_host_enabled }}
+{{-         $triton_ephemeral = "2Gi" }}
+{{-       else }}
+{{-         $len := len $model_gen_quota }}
+{{-         $len = sub $len 2 }}
+{{-         $substr := substr 0 (int $len) $model_gen_quota }}
+{{-         $num := (int $substr) }}
+{{-         $num = add 2 $num }}
+{{-         $triton_ephemeral = printf "%dGi" $num }}
 {{-       end }}
 {{-     end }}
 {{-     with .gpu }}

--- a/deploy/Kubernetes/worker/charts/trtllm/values.schema.json
+++ b/deploy/Kubernetes/worker/charts/trtllm/values.schema.json
@@ -1,0 +1,600 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "copyright": [
+    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.",
+    "SPDX-License-Identifier: Apache-2.0",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License.",
+    "You may obtain a copy of the License at",
+    "http://www.apache.org/licenses/LICENSE-2.0",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
+  "properties": {
+    "image": {
+      "description": "Configuration options related to the Triton Distributed Worker container image.",
+      "properties": {
+        "pullSecrets": {
+          "description": "Optional list of pull secrets to be used when downloading the Triton Distributed Worker container image. Optional list of pull secrets to be used when downloading the Triton Distributed Worker container image.",
+          "oneOf": [
+            {
+              "items": [
+                {
+                  "properties": {
+                    "name": {
+                      "$ref": "#/$defs/kubernetes_label",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "name": {
+          "description": "Name of the container image containing the version of Triton Distributed Worker container image to be used.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "kubernetes": {
+      "description": "Configurations option related to the Kubernetes objects created by the chart.",
+      "properties": {
+        "checks": {
+          "description": "Optional configuration options controlling how the cluster monitors the health of Triton Distributed Worker deployment(s).",
+          "properties": {
+            "liveness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed Worker instance is \"alive\" and responsive.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"alive\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster beings to attempt to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is healthy.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "readiness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed Worker instance is ready.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"ready\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster beings to attempt to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is ready.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+        "labels": {
+          "description": "Optional set of labels to be applied to created Kubernetes objects. These labels can be used for association with a preexisting service object.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "tolerations": {
+          "description": "Tolerations applied to every pod deployed as part of this deployment.",
+          "oneOf": [
+            {
+              "items": { "type": "object" },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "modelRepository": {
+      "description": "Configuration options related to the model repository used by the Triton Distributed Worker to load model(s).",
+      "properties": {
+        "modelGeneration": {
+          "description": "Configuration options related to the generation of TRTLLM plan and engine files from a source model files.",
+          "properties": {
+            "enabled": {
+              "description": "When `true`, the plan and engine files will be generated when the worker is deployed; otherwise it is assumed the necessary files have been pre-generated and will be provided without the need for the generation steps.",
+              "oneOf": [
+                { "type": "boolean" },
+                { "type": "null" }
+              ]
+            },
+            "hostCache": {
+              "description": "Configurations options related to the caching of generated model using host file system.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, model generation will be completed as part of an initialization phase, and cached on the host machine to avoid repeating model generation costs when possible. When `false`, each worker pod will perform the model generation steps without caching results.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "hostPath": {
+                  "description": "Host file system path to the TRTLLM model cache directory.",
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "options": {
+              "description": "Lists of options to pass to the model generation tool chain.",
+              "properties": {
+                "convertCheckpoint": {
+                  "description": "List of options specifically for the `convert_checkpoint.py` model generation script.",
+                  "oneOf": [
+                    {
+                      "items": { "type": "string" },
+                      "minItems": 0,
+                      "type": "array"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "trtllmBuild": {
+                  "description": "List of options specifically for the `trtllm-build` model generation tool.",
+                  "oneOf": [
+                    {
+                      "items": { "type": "string" },
+                      "minItems": 0,
+                      "type": "array"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "path": {
+              "description": "Container local file system path to the model generation checkpoint directory.",
+              "oneOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ]
+            },
+            "sizeLimit": {
+              "description": "Storage space quota applied to the model cache. Value must be provided in Kubernetes' unit notation.",
+              "oneOf": [
+                { "$ref": "#/$defs/kubernetes_units" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+        "path": {
+          "description": "Local file-system path within the container to the model repository.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "volumeMounts": {
+          "description": "Persistent volumes to be mounted with the container.",
+          "oneOf": [
+            {
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "Name to associate the volume mount with. Volume mount names must be unique and cannot contain spaces or special characters.",
+                    "$ref": "#/$defs/kubernetes_label"
+                  },
+                  "path": {
+                    "description": "Path relative to model repository's root path. When not provided, the volume is mounted to the root of the repository. Overlapping mount paths can cause errors during container deployment.",
+                    "oneOf": [
+                      { "type": "string" },
+                      { "type": "null" }
+                    ]
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "Name of the persistent volume claim used to mount a folder containing the model(s) Triton will load.",
+                    "$ref": "#/$defs/kubernetes_label"
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "name",
+                  "persistentVolumeClaim"
+                ]
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "triton": {
+      "description": "Configuration options related to the operation of Triton Distributed Worker.",
+      "properties": {
+        "componentName": {
+          "description": "Name of the Triton Distributed Worker in the distributed deployment.",
+          "pattern": "^[a-z]([a-z09_\\-]{0,29}[a-z0-9])?$",
+          "type": "string"
+        },
+        "distributed": {
+          "description": "Configuration options related to organization of Triton Distributed workflows.",
+          "properties": {
+            "requestPlane": {
+              "description": "Configuration options related to connecting the Triton Distributed Worker to its Triton Distributed Request Plane.",
+              "properties": {
+                "serverKind": {
+                  "description": "Kind of server providing Triton Distributed Request Plane functionality. Supported options: 'nats-io'.",
+                  "oneOf": [
+                    {
+                      "pattern": "^nats-io$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "serviceName": {
+                  "description": "Name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.",
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
+                },
+                "servicePort": {
+                  "description": "Networking port to be used to interact with the Triton Distributed Request Plane.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "instance": {
+              "description": "Optional configuration options related to the number of Triton Distributed Worker pods are deployed.",
+              "properties": {
+                "count": {
+                  "description": "Number of worker instances (whole model) to be deployed as part of this helm chart.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "parallelism": {
+                  "description": "Optional configuration options related to how work for a single model is spread across multiple pods. When the product of `pipeline`*`tensor` is greater than 1, multiple pods will be deployed as a single logical worker.",
+                  "properties": {
+                    "pipeline": {
+                      "description": "Pipeline parallelism involves sharding the model (vertically) into chunks, where each chunk comprises a subset of layers that is executed on a separate device.",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type": "null" }
+                      ]
+                    },
+                    "tensor": {
+                      "description": "Tensor parallelism involves sharding (horizontally) individual layers of the model into smaller, independent blocks of computation that can be executed on different devices.",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type": "null" }
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    { "type": "object" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "logging": {
+              "description": "Logging configuration options specific to Triton Distributed Worker.",
+              "properties": {
+                "useIso8601": {
+                  "description": "When `true` Triton Distributed Worker logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "verbose": {
+                  "description": "When `true` Triton Distributed Worker uses verbose logging; otherwise standard logging is used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "ports": {
+              "description": "Configuration options for the management of the Triton Distributed Worker exposed.",
+              "properties": {
+                "data": {
+                  "description": "Container port exposed to enable Triton Distributed Worker data-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "health": {
+                  "description": "Container port exposed to enable Triton Distributed Worker Kubernetes health reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "metrics": {
+                  "description": "Container port exposed to enable Triton Distributed Worker metrics reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "request": {
+                  "description": "Container port exposed to enable Triton Distributed Worker request-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "resources": {
+              "description": "Configuration options related to the resources assigned to Triton Distributed Worker and loaded model(s).",
+              "properties": {
+                "cpu": {
+                  "description": "Number of logical CPU cores required by the Triton Distributed Worker and loaded model(s).",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "ephemeral": {
+                  "description": "Ephemeral storage (aka local disk usage) allowance. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type": "null" }
+                  ]
+                },
+                "gpu": {
+                  "description": "Configuration options related GPU resources to be assigned to the Triton Distributed Worker and loaded model(s).",
+                  "properties": {
+                    "count": {
+                      "description": "Number of GPUs required by the Triton Distributed Worker and loaded model(s).",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type" : "null" }
+                      ]
+                    },
+                    "product": {
+                      "description": "List of the GPUs support `.model` and to which Triton Distributed Worker instances can be deployed.",
+                      "oneOf": [
+                        {
+                          "items": {
+                            "$ref": "#/$defs/kubernetes_label"
+                          },
+                          "type": "array"
+                        },
+                        { "type": "null" }
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    { "type": "object" },
+                    { "type": "null" }
+                  ]
+                },
+                "memory": {
+                  "description": "Amount of CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s). Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                },
+                "sharedMemory": {
+                  "description": "Amount of shared CPU visible (aka host) memory available the Triton Distributed Worker and loaded model(s). Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": [
+        "componentName"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "triton"
+  ],
+  "type": "object",
+  "$defs": {
+    "container_port": {
+      "maximum": 65535,
+      "minimum": 1025,
+      "type": "integer"
+    },
+    "kubernetes_label": {
+      "pattern": "^[a-z0-9]([a-z-09_\\-\\/\\.]{0,61}[a-z0-9])?$",
+      "type": "string"
+    },
+    "kubernetes_units": {
+      "pattern": "^\\d+[GKMgkm]i$",
+      "type": "string"
+    },
+    "service_port": {
+      "maximum": 32767,
+      "minimum": 30000,
+      "type": "integer"
+    }
+  }
+}

--- a/deploy/Kubernetes/worker/charts/trtllm/values.yaml
+++ b/deploy/Kubernetes/worker/charts/trtllm/values.yaml
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `image` contains configuration options related to the Triton Distributed Worker container image.
+image: # (required)
+  # `image.pullSecrets` is an optional list of pull secrets to be used when downloading the Triton Distributed Worker container image.
+  pullSecrets: [] # (optional)
+  # - name: pull-secret-name
+  # `image.name` is the name of the container image containing the version of Triton Distributed Worker container image to be used.
+  name: # (required)
+
+# `kubernetes` contains configurations option related to the Kubernetes objects created by the chart.
+kubernetes: # (optional)
+  # `kubernetes.annotations` is an optional set of annotations to be applied to create Kubernetes objects.
+  annotations: [] # (optional)
+  # `kubernetes.checks` are optional configuration options controlling how the cluster monitors the health of Triton Distributed Worker deployment(s).
+  checks:
+    # `kubernetes.checks.liveness` are configuration options related to how the cluster determines that a Triton Distributed Worker instance is "alive" and responsive.
+    liveness:
+      # `kubernetes.checks.liveness.enabled` when `true`, instructs the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.
+      enabled: # (default true)
+      # `kubernetes.checks.liveness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "alive").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.liveness.initialDelaySeconds` is the minimum wait before the cluster beings to attempt to determine the health of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.liveness.periodSeconds` is the minimum period between attempts to determine the health of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.liveness.successThreshold` is the number of successful responses required to determine that a pod is healthy.
+      successThreshold: # (default 1)
+    # `kubernetes.checks.readiness` contains configuration options related to how the cluster determines that a Triton Distributed Worker instance is ready.
+    readiness:
+      # `kubernetes.checks.readiness.enabled` when `true`, instructs the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.
+      enabled: # (default true)
+      # `kubernetes.checks.readiness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "ready").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.readiness.initialDelaySeconds` is the minimum wait before the cluster beings to attempt to determine the readiness of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.readiness.periodSeconds` is the minimum period between attempts to determine the readiness of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.readiness.successThreshold` is the number of successful responses required to determine that a pod is ready.
+      successThreshold: # (default 1)
+  # `kubernetes.labels` is an optional set of labels to be applied to created Kubernetes objects.
+  # These labels can be used for association with a preexisting service object.
+  labels: [] # (optional)
+  # `kubernetes.partOf` is an optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.
+  partOf: # (default: triton-distributed)
+  # `kubernetes.tolerations` are tolerations applied to every pod deployed as part of this deployment.
+  # Template already includes `nvidia.com/gpu=present:NoSchedule` when `resources.gpu` is specified.
+  tolerations: [] # (optional)
+
+# `modelRepository` contains configuration options related to the model repository used by the Triton Distributed Worker to load model(s).
+modelRepository: # (optional)
+  # `modelRepository.modelGeneration` contains configuration options related to the generation of TRTLLM plan and engine files from a source model files.
+  modelGeneration:
+    # `modelRepository.modelGeneration.enabled` when `true`, instructs the plan and engine files will be generated when the worker is deployed;
+    # otherwise it is assumed the necessary files have been pre-generated and will be provided without the need for the generation steps.
+    enabled: # (default true)
+    # `modelRepository.modelGeneration.hostCache` contains configurations options related to the caching of generated model using host file system.
+    hostCache:
+      # `modelRepository.modelGeneration.hostCache.enabled` when `true` instructs model generation to reuse previously generated models and cache newly generated on the host machine to avoid repeating model generation costs when possible.
+      # When `false`, each worker pod will perform the model generation steps without caching results.
+      enabled: # (default false)
+      # `modelRepository.modelGeneration.hostCache.hostPath` specifies the host file system path to the TRTLLM model cache directory.
+      hostPath: # (default '/triton/trtllm-cache')
+    # `modelRepository.modelGeneration.options` specifies lists of options to pass to the model generation tool chain.
+    options:
+      # `modelRepository.modelGeneration.options.convertCheckpoint` specifies a list of options specifically for the `convert_checkpoint.py` model generation script.
+      convertCheckpoint: []
+      # `modelRepository.modelGeneration.options.trtllmBuild` specifies a list of options specifically for the `trtllm-build` model generation tool.
+      trtllmBuild: []
+    # `modelRepository.modelGeneration.options.path` specifies a container local file system path to the model generation checkpoint directory.
+    path: # (default `/var/run/trtllm`)
+    # `modelRepository.modelGeneration.options.sizeLimit` specifies a storage space quota applied to the model cache.
+    # Value must be provided in Kubernetes' unit notation.
+    sizeLimit: # (default 96Gi)
+  # `modelRepository.path` is a local file-system path within the container to the model repository.
+  # When `persistentVolumeClaim` is specified, this is the path to which the PVC will be mounted.
+  path: # (default: /var/run/models)
+  # `modelRepository.volumeMounts` are persistent volumes (PV) to be mounted with the Triton Distributed Worker container.
+  volumeMounts: [] # (optional)
+  #   # `modelRepository.volumeMounts.name` is the name to associate the volume mount with. Volume mount names must be unique and cannot contain spaces or special characters.
+  # - name: # (required)
+  #   # `modelRepository.volumeMounts.path` is the file-system path relative to model repository's root path to which the volume will be mounted to.
+  #   # When not provided, the volume is mounted to the root of the repository.
+  #   # Overlapping mount paths can cause errors during container deployment.
+  #   path: # (optional)
+  #   # `modelRepository.volumeMounts.persistentVolumeclaim` is the name of the persistent volume claim (PVC) used to mount a folder containing the model(s) Triton will load.
+  #   persistentVolumeClaim: # (required)
+
+# `triton` contains configuration options related to the operation of Triton Distributed Worker.
+triton: # (required)
+  # `triton.componentName` is the name of the Triton Distributed Worker in the distributed deployment.
+  componentName: # (required)
+  # `triton.distributed` contains configuration options related to organization of Triton Distributed workflows.
+  distributed:
+    # `triton.distributed.requestPlane` contains configuration options related to connecting the Triton Distributed Worker to its Triton Distributed Request Plane.
+    requestPlane:
+      # `triton.distributed.requestPlane.serverKind` is the "kind" of server providing Triton Distributed Request Plane functionality.
+      # Supported options: `nats-io`.
+      serverKind: # (default nats-io)
+      # `triton.distributed.requestPlane.serviceName` is the name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.
+      # The service name will be used to resolve the network communication addressing within the cluster (example: <serviceName>.svc.cluster.local).
+      serviceName: # (default triton-distributed_request-plane)
+      # `triton.distributed.requestPlane.servicePort` is the networking port to be used to interact with the Triton Distributed Request Plane.
+      servicePort: # (default 30222)
+  # `triton.instance` are optional configuration options related to the number of Triton Distributed Worker pods are deployed.
+  instance:
+    # `triton.instance.count` is the number of worker instances (whole model) to be deployed as part of this helm chart.
+    count: # (default 1)
+    # `triton.instance.parallelism` contains optional configuration options related to how work for a single model is spread across multiple pods.
+    # When the product of `pipeline`*`tensor` is greater than 1, multiple pods will be deployed as a single logical worker.
+    parallelism:
+      # `triton.instance.parallelism.pipeline` specifies the level of pipeline parallelism used by the model hosted by the Triton Distributed Worker.
+      # Pipeline parallelism involves sharding the model (vertically) into chunks, where each chunk comprises a subset of layers that is executed on a separate device.
+      pipeline: # (default 1)
+      # `triton.instance.parallelism.tensor` specifies the level of tensor parallelism used by the model hosted by the Triton Distributed Worker.
+      # Tensor parallelism involves sharding (horizontally) individual layers of the model into smaller, independent blocks of computation that can be executed on different devices.
+      tensor: # (default 1)
+  # `triton.logging` contains logging configuration options specific to Triton Distributed Worker.
+  logging: # (optional)
+    # `triton.logging.useIso8601` when `true`, instructs Triton Distributed Worker logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.
+    useIso8601: # (default: false)
+    # `triton.logging.verbose` when `true`, instructs Triton Distributed Worker uses verbose logging; otherwise standard logging is used.
+    verbose: # (default: false)
+  # `triton.ports` contains configuration options for the management of the Triton Distributed Worker exposed.
+  ports: # (optional)
+    # `triton.ports.data` is the container port exposed to enable Triton Distributed Worker data-plane operations.
+    data: # (default 9346)
+    # `triton.ports.health` is the container port exposed to enable Triton Distributed Worker Kubernetes health reporting.
+    health: # (default 8000)
+    # `triton.ports.metrics` is the container port exposed to enable Triton Distributed Worker metrics reporting.
+    metrics: # (default 9347)
+    # `triton.ports.request` is the container port exposed to enable Triton Distributed Worker request-plane operations.
+    request: # (default 9345)
+  # `triton.resources` contains configuration options related to the resources assigned to Triton Distributed Worker and loaded model(s).
+  resources: # (optional)
+    # `triton.resources.cpu` is the number of logical CPU cores required by the Triton Distributed Worker and loaded model(s).
+    cpu: # (default: 4)
+    # `triton.resources.ephemeral` is the ephemeral storage (aka local disk usage) allowance.
+    # Ephemeral storage MUST include any shared memory allocated to Triton Distributed Worker.
+    # Value must be provided in Kubernetes' unit notation.
+    ephemeral: # (default: 1Gi)
+    # `triton.resources.gpu` contains configuration options related GPU resources to be assigned to the Triton Distributed Worker and loaded model(s).
+    gpu: # (optional)
+      # `triton.resources.gpu.count` specifies the number of GPUs required by the Triton Distributed Worker and loaded model(s).
+      count: # (default: 1)
+      # `triton.resources.gpu.product` defines list of the supported GPUs to which Triton Distributed Worker instance(s) can be deployed.
+      # Value must match the node's `.metadata.labels.nvidia.com/gpu.product` label provided by the NVIDIA GPU Discovery Service.
+      # Run 'kubectl get nodes' to find node names.
+      # Run 'kubectl describe node <node_name>' to inspect a node's labels.
+      product: [] # (optional)
+    # `triton.resources.memory` specifies the amount of CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s).
+    # Value must be provided in Kubernetes' unit notation.
+    memory: # (default: 16Gi)
+    # `triton.resources.sharedMemory` specifies about amount of shared CPU visible (aka host) memory available the Triton Distributed Worker and loaded model(s).
+    # Value must be provided in Kubernetes' unit notation.
+    sharedMemory: # (default: 512Mi)

--- a/deploy/Kubernetes/worker/charts/vllm/Chart.yaml
+++ b/deploy/Kubernetes/worker/charts/vllm/Chart.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: 1.0.0
+description: Triton Distributed Worker for vLLM
+icon: https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/logo-and-brand/01-nvidia-logo-vert-500x200-2c50-d@2x.png
+name: triton-distributed_worker-vllm
+version: 1.0.0

--- a/deploy/Kubernetes/worker/charts/vllm/templates/_helpers.tpl
+++ b/deploy/Kubernetes/worker/charts/vllm/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Annotation Groups
+{{- define "triton.annotations.default" }}
+triton-distributed: "{{ .Release.Name }}.{{ .Chart.AppVersion | default "0.0" }}"
+{{-   with .Values.kubernetes }}
+{{-     with .annotations }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{- end -}}
+
+{{- define "triton.annotations.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+{{-   template "triton.annotations.default" . }}
+{{- end -}}
+
+# Label Groups
+{{- define "triton.labels.default" }}
+{{-   template "triton.label.appInstance" . }}
+{{-   template "triton.label.appName" . }}
+{{-   template "triton.label.appPartOf" . }}
+{{-   template "triton.label.appVersion" . }}
+{{- end -}}
+
+{{- define "triton.labels.chart" }}
+{{-   template "triton.labels.default" . }}
+{{-   template "triton.label.appManagedBy" . }}
+{{-   template "triton.label.chart" . }}
+{{-   with .Values.kubernetes }}
+{{-     with .labels }}
+{{        toYaml . }}
+{{-     end }}
+{{-   end }}
+{{-   template "triton.label.release" . }}
+{{- end -}}
+
+# Label Values
+{{- define "triton.label.appInstance" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "triton.label.appManagedBy" }}
+{{-   $service_name := "triton-distributed" }}
+{{-   with .Release.Service }}
+{{-     $service_name = . }}
+{{-   end }}
+app.kubernetes.io/managed-by: {{ $service_name }}
+{{- end }}
+
+{{- define "triton.label.appName" }}
+app.kubernetes.io/name: {{ required "Property '.triton.componentName' is required." .Values.triton.componentName }}
+{{- end }}
+
+{{- define "triton.label.appPartOf" }}
+{{-   $part_of := "triton-distributed" }}
+{{-   with .Values.kubernetes }}
+{{-     with .partOf }}
+{{-       $part_of = . }}
+{{-     end }}
+{{-   end }}
+app.kubernetes.io/part-of: {{ $part_of }}
+{{- end }}
+
+{{- define "triton.label.appVersion" }}
+app.kubernetes.io/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.chart" }}
+helm.sh/chart: {{ .Chart.Name | quote }}
+helm.sh/version: {{ .Chart.Version | default "0.0" | quote }}
+{{- end }}
+
+{{- define "triton.label.release" }}
+release: "{{ .Chart.Name }}_v{{ .Chart.Version | default "0.0" }}"
+{{- end }}

--- a/deploy/Kubernetes/worker/charts/vllm/templates/worker-deployment.yaml
+++ b/deploy/Kubernetes/worker/charts/vllm/templates/worker-deployment.yaml
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $triton_image_name := "" }}
+{{- with $.Values.image }}
+{{-   $triton_image_name = required "Property '.image.name' is required." .name }}
+{{- else }}
+{{-   fail "Property '.image' is required." }}
+{{- end }}
+{{- $component_name := "" }}
+{{- $instance_count := 1 }}
+{{- $k8s_liveness_delay := 10 }}
+{{- $k8s_liveness_enabled := true }}
+{{- $k8s_liveness_fail := 15 }}
+{{- $k8s_liveness_period := 2 }}
+{{- $k8s_liveness_success := 1 }}
+{{- $k8s_readiness_delay := 10 }}
+{{- $k8s_readiness_enabled := true }}
+{{- $k8s_readiness_fail := 15 }}
+{{- $k8s_readiness_period := 2 }}
+{{- $k8s_readiness_success := 1 }}
+{{- $request_plane_kind := "nats-io" }}
+{{- $request_plane_name := "triton-distributed_request-plane" }}
+{{- $request_plane_port := 30222 }}
+{{- $parallel_pipeline := 1 }}
+{{- $parallel_tensor := 1 }}
+{{- $parallel_world := 1 }}
+{{- $port_data := 9346 }}
+{{- $port_health := 8000 }}
+{{- $port_metrics := 9347 }}
+{{- $port_request := 9345 }}
+{{- $triton_cpu := 4 }}
+{{- $triton_ephemeral := "1Gi" }}
+{{- $triton_gpu := 1 }}
+{{- $triton_logging_iso8601 := 0 }}
+{{- $triton_logging_verbose := 0 }}
+{{- $triton_memory := "16Gi" }}
+{{- $triton_shared := "512Mi" }}
+{{- with $.Values.kubernetes }}
+{{-   with .checks }}
+{{-     with .liveness }}
+{{-       $k8s_liveness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_liveness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_liveness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_liveness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_liveness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-     with .readiness }}
+{{-       $k8s_readiness_enabled = ne false .enabled }}
+{{-       with .failureThreshold }}
+{{-         $k8s_readiness_fail = (int .) }}
+{{-       end }}
+{{-       with .initialDelaySeconds }}
+{{-         $k8s_readiness_delay = (int .) }}
+{{-       end }}
+{{-       with .periodSeconds }}
+{{-         $k8s_readiness_period = (int .) }}
+{{-       end }}
+{{-       with .successThreshold }}
+{{-         $k8s_readiness_success = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.triton }}
+{{-   $component_name = required "Property '.triton.componentName' is required." .componentName }}
+{{-   with .distributed }}
+{{-     with .manifold }}
+{{-       with .serverKind }}
+{{-         $request_plane_kind = . }}
+{{-       end }}
+{{-       with .serviceName }}
+{{-         $request_plane_name = . }}
+{{-       end }}
+{{-       with .servicePort }}
+{{-         $request_plane_port = (int .) }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{-   with .instance }}
+{{-     with .count }}
+{{-       $instance_count = (int .) }}
+{{-     end }}
+{{-     with .parallelism }}
+{{-       with .pipeline }}
+{{-         $parallel_pipeline = (int .) }}
+{{-       end }}
+{{-       with .tensor }}
+{{-         $parallel_tensor = (int .) }}
+{{-       end }}
+{{-       $parallel_world = mul $parallel_pipeline $parallel_tensor }}
+{{-     end }}
+{{-   end }}
+{{-   with .logging }}
+{{-     if .useIso8601 }}
+{{-       $triton_logging_iso8601 = 1 }}
+{{-     end }}
+{{-     if .verbose }}
+{{-       $triton_logging_verbose = 1 }}
+{{-     end }}
+{{-   end }}
+{{-   with .ports }}
+{{-     with .data }}
+{{-       $port_data = (int .) }}
+{{-     end }}
+{{-     with .health }}
+{{-       $port_health = (int .) }}
+{{-     end }}
+{{-     with .metrics }}
+{{-       $port_metrics = (int .) }}
+{{-     end }}
+{{-     with .request }}
+{{-       $port_request = (int .) }}
+{{-     end }}
+{{-   end }}
+{{-   with .resources }}
+{{-     with .cpu }}
+{{-       $triton_cpu = (int .) }}
+{{-     end }}
+{{-     with .ephemeral }}
+{{-       $triton_ephemeral = . }}
+{{-     end }}
+{{-     with .gpu }}
+{{-       $triton_gpu = (int .count) }}
+{{-     end }}
+{{-     with .memory }}
+{{-       $triton_memory = . }}
+{{-     end }}
+{{-     with .sharedMemory }}
+{{-       $triton_shared = . }}
+{{-     end }}
+{{-   end }}
+{{- else }}
+{{-   fail "Property '.triton' is required." }}
+{{- end }}
+{{- $model_repo_path := "/var/run/models" }}
+{{- with $.Values.modelRepository }}
+{{-   with .path }}
+{{-     $model_repo_path = trimSuffix "/" . }}
+{{-   end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}
+  annotations:
+{{- include "triton.annotations.chart" . | indent 4 }}
+  labels:
+    app: {{ $.Release.Name }}
+    app.kubernetes.io/component: worker
+{{- include "triton.labels.chart" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}
+      app.kubernetes.io/component: worker
+  replicas: {{ $instance_count }}
+  template:
+    metadata:
+      annotations:
+{{- include "triton.annotations.chart" . | indent 8 }}
+      labels:
+        app: {{ $.Release.Name }}
+        app.kubernetes.io/component: worker
+{{- include "triton.labels.chart" . | indent 8 }}
+    spec:
+{{- if ne $triton_gpu 0 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu
+                operator: Exists
+{{-   with $.Values.triton }}
+{{-     with .resources }}
+{{-       with .gpu }}
+{{-         with .product }}
+{{-           if len . }}
+              - key: nvidia.com/gpu.product
+                operator: In
+                values:
+{{            toYaml . | indent 16 }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      containers:
+      - name: triton
+        command:
+        - --model-repository={{ $model_repo_path }}
+{{- if $triton_logging_iso8601 }}
+        - --iso8601
+{{- end}}
+{{- if $triton_logging_verbose }}
+        - --verbose
+{{- end }}
+        env:
+        - TRITON_COMPONENT_NAME: {{ $component_name }}
+{{- if gt $parallel_world 1 }}
+        - TRITON_LLM_PP: {{ $parallel_pipeline }}
+        - TRITON_LLM_TP: {{ $parallel_tensor }}
+{{- end }}
+        - TRITON_request_plane_kind: {{ $request_plane_kind }}
+        - TRITON_request_plane_name: {{ $request_plane_name }}
+        - TRITON_request_plane_port: {{ $request_plane_port }}
+        - TRITON_MODEL_REPOSITORY: {{ $model_repo_path }}
+{{- if ne $port_data 9346 }}
+        - TRITON_PORT_DATA: {{ $port_data }}
+{{- end }}
+{{- if ne $port_health 8000 }}
+        - TRITON_PORT_HEALTH: {{ $port_health }}
+{{- end }}
+{{- if ne $port_metrics 9347 }}
+        - TRITON_PORT_METRICS: {{ $port_metrics }}
+{{- end }}
+{{- if ne $port_request 9345 }}
+        - TRITON_PORT_REQUEST: {{ $port_request }}
+{{- end }}
+{{- if false }}
+# What are these and are they needed? HELP!
+        - VLLM_ATTENTION_BACKEND: 0
+        - VLLM_CONTEXT_WORKERS: 0
+        - VLLM_CONTEXT_TP_SIZE: 0
+        - VLLM_DATA_PLANE_BACKEND: NCCL
+        - VLLM_GENERATE_TP_SIZE: 0
+        - VLLM_GENERATE_WORKERS: 0
+        - VLLM_TORCH_HOST: 0
+        - VLLM_TORCH_PORT: 0
+        - VLLM_WORKER_ID: 0
+        - VLLM_WORKER_MULTIPROC_METHOD: 0
+{{- end }}
+        image: {{ $triton_image_name }}
+        imagePullPolicy: IfNotPresent
+{{- if $k8s_liveness_enabled }}
+        livenessProbe:
+          failureThreshold: {{ $k8s_liveness_fail }}
+          httpGet:
+            path: /v2/health/live
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_liveness_delay }}
+          periodSeconds: {{ $k8s_liveness_period }}
+          successThreshold: {{ $k8s_liveness_success }}
+{{- end }}
+        ports:
+        - containerPort: {{ $port_health }}
+          name: health
+        - containerPort: {{ $port_request }}
+          name: request
+        - containerPort: {{ $port_data }}
+          name: data
+        - containerPort: {{ $port_metrics }}
+          name: metrics
+{{- if $k8s_readiness_enabled }}
+        readinessProbe:
+          failureThreshold: {{ $k8s_readiness_fail }}
+          httpGet:
+            path: /v2/health/ready
+            port: {{ $port_health }}
+          initialDelaySeconds: {{ $k8s_readiness_delay }}
+          periodSeconds: {{ $k8s_readiness_period }}
+          successThreshold: {{ $k8s_readiness_success }}
+{{- end }}
+        resources:
+          limits:
+            cpu: {{ $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- if gt $triton_gpu 0 }}
+            nvidia.com/gpu: {{ $triton_gpu }}
+{{- end }}
+          requests:
+            cpu: {{ mul $triton_cpu }}
+            ephemeral-storage: {{ $triton_ephemeral }}
+            memory: {{ $triton_memory }}
+{{- if gt $triton_gpu 0 }}
+            nvidia.com/gpu: {{ $triton_gpu }}
+{{- end }}
+        volumeMounts:
+{{- with $.Values.modelRepository }}
+{{-   with .volumeMounts }}
+{{-     range . }}
+{{-       $mount_path := $model_repo_path }}
+{{-       $volume_name := required "Property '.modelRepository.volumeMounts[*].name' is required." .name }}
+{{-       if eq "shared-memory" $volume_name }}
+{{-         fail "Property '.modelRepository.volumeMounts[*].name' cannot be `shared-memory` because it is a reserved name." }}
+{{-       end }}
+{{-       with .path }}
+{{-         $mount_path = printf "%s/%s" $model_repo_path (trimPrefix "/" .) }}
+{{-         if regexMatch "/\\.\\./?" $mount_path }}
+{{-           fail (printf "Value of property `.modelRepository.volumeMounts[*].path' `%s` is illegal because `%s` is not a sub-directory of `%s`." . (clean $mount_path) $model_repo_path) }}
+{{-         end }}
+{{-       end }}
+        - mountPath: {{ $mount_path }}
+          name: {{ $volume_name  }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+        - mountPath: /dev/shm
+          name: shared-memory
+{{- with $.Values.image }}
+{{-   with .pullSecrets }}
+{{-     if len . }}
+      imagePullSecrets:
+{{        toYaml . | indent 6 }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      tolerations:
+{{- with $.Values.triton }}
+{{-   with .resources }}
+{{-     with .gpu }}
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- with $.Values.kubernetes }}
+{{-   with .tolerations }}
+{{      toYaml . | indent 6 }}
+{{-   end }}
+{{- end }}
+      volumes:
+{{- with $.Values.modelRepository }}
+{{-   with .volumeMounts }}
+{{-     range . }}
+      - name: {{ required "Property '.modelRepository.volumeMounts.name' is required." .name  }}
+        persistentVolumeClaim:
+          claimName: {{ required "Property '.modelRepository.volumeMounts.persistentVolumeClaim' is required." .persistentVolumeClaim }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ $triton_shared }}

--- a/deploy/Kubernetes/worker/charts/vllm/values.schema.json
+++ b/deploy/Kubernetes/worker/charts/vllm/values.schema.json
@@ -1,0 +1,516 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "copyright": [
+    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.",
+    "SPDX-License-Identifier: Apache-2.0",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License.",
+    "You may obtain a copy of the License at",
+    "http://www.apache.org/licenses/LICENSE-2.0",
+    "Unless required by applicable law or agreed to in writing, software",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "See the License for the specific language governing permissions and",
+    "limitations under the License."
+  ],
+  "properties": {
+    "image": {
+      "description": "Configuration options related to the Triton Distributed Worker container image.",
+      "properties": {
+        "pullSecrets": {
+          "description": "Optional list of pull secrets to be used when downloading the Triton Distributed Worker container image. Optional list of pull secrets to be used when downloading the Triton Distributed Worker container image.",
+          "oneOf": [
+            {
+              "items": [
+                {
+                  "properties": {
+                    "name": {
+                      "$ref": "#/$defs/kubernetes_label",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "name": {
+          "description": "Name of the container image containing the version of Triton Distributed Worker container image to be used.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "kubernetes": {
+      "description": "Configurations option related to the Kubernetes objects created by the chart.",
+      "properties": {
+        "checks": {
+          "description": "Optional configuration options controlling how the cluster monitors the health of Triton Distributed Worker deployment(s).",
+          "properties": {
+            "liveness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed Worker instance is \"alive\" and responsive.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"alive\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster beings to attempt to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the health of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is healthy.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "readiness": {
+              "description": "Configuration options related to how the cluster determines that a Triton Distributed Worker instance is ready.",
+              "properties": {
+                "enabled": {
+                  "description": "When `true`, the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "failureThreshold": {
+                  "description": "Number of failed responses required to determine a pod is not responsive (aka \"ready\").",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "initialDelaySeconds": {
+                  "description": "Minimum wait before the cluster beings to attempt to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "periodSeconds": {
+                  "description": "Minimum period between attempts to determine the readiness of the pod.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "successThreshold": {
+                  "description": "Number of successful responses required to determine that a pod is ready.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+        "labels": {
+          "description": "Optional set of labels to be applied to created Kubernetes objects. These labels can be used for association with a preexisting service object.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/kubernetes_label"
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        },
+        "tolerations": {
+          "description": "Tolerations applied to every pod deployed as part of this deployment.",
+          "oneOf": [
+            {
+              "items": { "type": "object" },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "modelRepository": {
+      "description": "Configuration options related to the model repository used by the Triton Distributed Worker to load model(s).",
+      "properties": {
+        "path": {
+          "description": "Local file-system path within the container to the model repository.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "volumeMounts": {
+          "description": "Persistent volumes to be mounted with the container.",
+          "oneOf": [
+            {
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "Name to associate the volume mount with. Volume mount names must be unique and cannot contain spaces or special characters.",
+                    "$ref": "#/$defs/kubernetes_label"
+                  },
+                  "path": {
+                    "description": "Path relative to model repository's root path. When not provided, the volume is mounted to the root of the repository. Overlapping mount paths can cause errors during container deployment.",
+                    "oneOf": [
+                      { "type": "string" },
+                      { "type": "null" }
+                    ]
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "Name of the persistent volume claim used to mount a folder containing the model(s) Triton will load.",
+                    "$ref": "#/$defs/kubernetes_label"
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "name",
+                  "persistentVolumeClaim"
+                ]
+              },
+              "minItems": 0,
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "triton": {
+      "description": "Configuration options related to the operation of Triton Distributed Worker.",
+      "properties": {
+        "componentName": {
+          "description": "Name of the Triton Distributed Worker in the distributed deployment.",
+          "pattern": "^[a-z]([a-z09_\\-]{0,29}[a-z0-9])?$",
+          "type": "string"
+        },
+        "distributed": {
+          "description": "Configuration options related to organization of Triton Distributed workflows.",
+          "properties": {
+            "requestPlane": {
+              "description": "Configuration options related to connecting the Triton Distributed Worker to its Triton Distributed Request Plane.",
+              "properties": {
+                "serverKind": {
+                  "description": "Kind of server providing Triton Distributed Request Plane functionality. Supported options: 'nats-io'.",
+                  "oneOf": [
+                    {
+                      "pattern": "^nats-io$",
+                      "type": "string"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "serviceName": {
+                  "description": "Name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.",
+                  "oneOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
+                },
+                "servicePort": {
+                  "description": "Networking port to be used to interact with the Triton Distributed Request Plane.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "instance": {
+              "description": "Optional configuration options related to the number of Triton Distributed Worker pods are deployed.",
+              "properties": {
+                "count": {
+                  "description": "Number of worker instances (whole model) to be deployed as part of this helm chart.",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "parallelism": {
+                  "description": "Optional configuration options related to how work for a single model is spread across multiple pods. When the product of `pipeline`*`tensor` is greater than 1, multiple pods will be deployed as a single logical worker.",
+                  "properties": {
+                    "pipeline": {
+                      "description": "Pipeline parallelism involves sharding the model (vertically) into chunks, where each chunk comprises a subset of layers that is executed on a separate device.",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type": "null" }
+                      ]
+                    },
+                    "tensor": {
+                      "description": "Tensor parallelism involves sharding (horizontally) individual layers of the model into smaller, independent blocks of computation that can be executed on different devices.",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type": "null" }
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    { "type": "object" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "logging": {
+              "description": "Logging configuration options specific to Triton Distributed Worker.",
+              "properties": {
+                "useIso8601": {
+                  "description": "When `true` Triton Distributed Worker logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                },
+                "verbose": {
+                  "description": "When `true` Triton Distributed Worker uses verbose logging; otherwise standard logging is used.",
+                  "oneOf": [
+                    { "type": "boolean" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "ports": {
+              "description": "Configuration options for the management of the Triton Distributed Worker exposed.",
+              "properties": {
+                "data": {
+                  "description": "Container port exposed to enable Triton Distributed Worker data-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "health": {
+                  "description": "Container port exposed to enable Triton Distributed Worker Kubernetes health reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "metrics": {
+                  "description": "Container port exposed to enable Triton Distributed Worker metrics reporting.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                },
+                "request": {
+                  "description": "Container port exposed to enable Triton Distributed Worker request-plane operations.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/container_port" },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            },
+            "resources": {
+              "description": "Configuration options related to the resources assigned to Triton Distributed Worker and loaded model(s).",
+              "properties": {
+                "cpu": {
+                  "description": "Number of logical CPU cores required by the Triton Distributed Worker and loaded model(s).",
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "ephemeral": {
+                  "description": "Ephemeral storage (aka local disk usage) allowance. Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type": "null" }
+                  ]
+                },
+                "gpu": {
+                  "description": "Configuration options related GPU resources to be assigned to the Triton Distributed Worker and loaded model(s).",
+                  "properties": {
+                    "count": {
+                      "description": "Number of GPUs required by the Triton Distributed Worker and loaded model(s).",
+                      "oneOf": [
+                        {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        { "type" : "null" }
+                      ]
+                    },
+                    "product": {
+                      "description": "List of the GPUs support `.model` and to which Triton Distributed Worker instances can be deployed.",
+                      "oneOf": [
+                        {
+                          "items": {
+                            "$ref": "#/$defs/kubernetes_label"
+                          },
+                          "type": "array"
+                        },
+                        { "type": "null" }
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    { "type": "object" },
+                    { "type": "null" }
+                  ]
+                },
+                "memory": {
+                  "description": "Amount of CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s). Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                },
+                "sharedMemory": {
+                  "description": "Amount of shared CPU visible (aka host) memory available the Triton Distributed Worker and loaded model(s). Value must be provided in Kubernetes' unit notation.",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kubernetes_units" },
+                    { "type" : "null" }
+                  ]
+                }
+              },
+              "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": [
+        "componentName"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "image",
+    "triton"
+  ],
+  "type": "object",
+  "$defs": {
+    "container_port": {
+      "maximum": 65535,
+      "minimum": 1025,
+      "type": "integer"
+    },
+    "kubernetes_label": {
+      "pattern": "^[a-z0-9]([a-z-09_\\-\\/\\.]{0,61}[a-z0-9])?$",
+      "type": "string"
+    },
+    "kubernetes_units": {
+      "pattern": "^\\d+[GKMgkm]i$",
+      "type": "string"
+    },
+    "service_port": {
+      "maximum": 32767,
+      "minimum": 30000,
+      "type": "integer"
+    }
+  }
+}

--- a/deploy/Kubernetes/worker/charts/vllm/values.yaml
+++ b/deploy/Kubernetes/worker/charts/vllm/values.yaml
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `image` contains configuration options related to the Triton Distributed Worker container image.
+image: # (required)
+  # `image.pullSecrets` is an optional list of pull secrets to be used when downloading the Triton Distributed Worker container image.
+  pullSecrets: [] # (optional)
+  # - name: pull-secret-name
+  # `image.name` is the name of the container image containing the version of Triton Distributed Worker container image to be used.
+  name: # (required)
+
+# `kubernetes` contains configurations option related to the Kubernetes objects created by the chart.
+kubernetes: # (optional)
+  # `kubernetes.annotations` is an optional set of annotations to be applied to create Kubernetes objects.
+  annotations: [] # (optional)
+  # `kubernetes.checks` are optional configuration options controlling how the cluster monitors the health of Triton Distributed Worker deployment(s).
+  checks:
+    # `kubernetes.checks.liveness` are configuration options related to how the cluster determines that a Triton Distributed Worker instance is "alive" and responsive.
+    liveness:
+      # `kubernetes.checks.liveness.enabled` when `true`, instructs the cluster will actively determine if the pod is alive; otherwise the cluster will always assume the pod is alive.
+      enabled: # (default true)
+      # `kubernetes.checks.liveness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "alive").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.liveness.initialDelaySeconds` is the minimum wait before the cluster beings to attempt to determine the health of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.liveness.periodSeconds` is the minimum period between attempts to determine the health of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.liveness.successThreshold` is the number of successful responses required to determine that a pod is healthy.
+      successThreshold: # (default 1)
+    # `kubernetes.checks.readiness` contains configuration options related to how the cluster determines that a Triton Distributed Worker instance is ready.
+    readiness:
+      # `kubernetes.checks.readiness.enabled` when `true`, instructs the cluster will actively determine if the pod is ready; otherwise the cluster will always assume the pod is ready.
+      enabled: # (default true)
+      # `kubernetes.checks.readiness.failureThreshold` is the number of failed responses required to determine a pod is not responsive (aka "ready").
+      failureThreshold: # (default 15)
+      # `kubernetes.checks.readiness.initialDelaySeconds` is the minimum wait before the cluster beings to attempt to determine the readiness of the pod.
+      initialDelaySeconds: # (default 10)
+      # `kubernetes.checks.readiness.periodSeconds` is the minimum period between attempts to determine the readiness of the pod.
+      periodSeconds: # (default 2)
+      # `kubernetes.checks.readiness.successThreshold` is the number of successful responses required to determine that a pod is ready.
+      successThreshold: # (default 1)
+  # `kubernetes.labels` is an optional set of labels to be applied to created Kubernetes objects.
+  # These labels can be used for association with a preexisting service object.
+  labels: [] # (optional)
+  # `kubernetes.partOf` is an optional value to be used with the `app.kubernetes.io/part-of` label on created Kubernetes objects.
+  partOf: # (default: triton-distributed)
+  # `kubernetes.tolerations` are tolerations applied to every pod deployed as part of this deployment.
+  # Template already includes `nvidia.com/gpu=present:NoSchedule` when `resources.gpu` is specified.
+  tolerations: [] # (optional)
+
+# `modelRepository` contains configuration options related to the model repository used by the Triton Distributed Worker to load model(s).
+modelRepository: # (optional)
+  # `modelRepository.path` is a local file-system path within the container to the model repository.
+  # When `persistentVolumeClaim` is specified, this is the path to which the PVC will be mounted.
+  path: # (default: /var/run/models)
+  # `modelRepository.volumeMounts` are persistent volumes (PV) to be mounted with the Triton Distributed Worker container.
+  volumeMounts: [] # (optional)
+  #   # `modelRepository.volumeMounts.name` is the name to associate the volume mount with. Volume mount names must be unique and cannot contain spaces or special characters.
+  # - name: # (required)
+  #   # `modelRepository.volumeMounts.path` is the file-system path relative to model repository's root path to which the volume will be mounted to.
+  #   # When not provided, the volume is mounted to the root of the repository.
+  #   # Overlapping mount paths can cause errors during container deployment.
+  #   path: # (optional)
+  #   # `modelRepository.volumeMounts.persistentVolumeclaim` is the name of the persistent volume claim (PVC) used to mount a folder containing the model(s) Triton will load.
+  #   persistentVolumeClaim: # (required)
+
+# `triton` contains configuration options related to the operation of Triton Distributed Worker.
+triton: # (required)
+  # `triton.componentName` is the name of the Triton Distributed Worker in the distributed deployment.
+  componentName: # (required)
+  # `triton.distributed` contains configuration options related to organization of Triton Distributed workflows.
+  distributed:
+    # `triton.distributed.requestPlane` contains configuration options related to connecting the Triton Distributed Worker to its Triton Distributed Request Plane.
+    requestPlane:
+      # `triton.distributed.requestPlane.serverKind` is the "kind" of server providing Triton Distributed Request Plane functionality.
+      # Supported options: `nats-io`.
+      serverKind: # (default nats-io)
+      # `triton.distributed.requestPlane.serviceName` is the name of the Kubernetes Service handling DNS routing for the Triton Distributed Request Plane instances.
+      # The service name will be used to resolve the network communication addressing within the cluster (example: <serviceName>.svc.cluster.local).
+      serviceName: # (default triton-distributed_request-plane)
+      # `triton.distributed.requestPlane.servicePort` is the networking port to be used to interact with the Triton Distributed Request Plane.
+      servicePort: # (default 30222)
+  # `triton.instance` are optional configuration options related to the number of Triton Distributed Worker pods are deployed.
+  instance:
+    # `triton.instance.count` is the number of worker instances (whole model) to be deployed as part of this helm chart.
+    count: # (default 1)
+    # `triton.instance.parallelism` contains optional configuration options related to how work for a single model is spread across multiple pods.
+    # When the product of `pipeline`*`tensor` is greater than 1, multiple pods will be deployed as a single logical worker.
+    parallelism:
+      # `triton.instance.parallelism.pipeline` specifies the level of pipeline parallelism used by the model hosted by the Triton Distributed Worker.
+      # Pipeline parallelism involves sharding the model (vertically) into chunks, where each chunk comprises a subset of layers that is executed on a separate device.
+      pipeline: # (default 1)
+      # `triton.instance.parallelism.tensor` specifies the level of tensor parallelism used by the model hosted by the Triton Distributed Worker.
+      # Tensor parallelism involves sharding (horizontally) individual layers of the model into smaller, independent blocks of computation that can be executed on different devices.
+      tensor: # (default 1)
+  # `triton.logging` contains logging configuration options specific to Triton Distributed Worker.
+  logging: # (optional)
+    # `triton.logging.useIso8601` when `true`, instructs Triton Distributed Worker logs are formatted using the ISO8601 standard; otherwise Triton's default format will be used.
+    useIso8601: # (default: false)
+    # `triton.logging.verbose` when `true`, instructs Triton Distributed Worker uses verbose logging; otherwise standard logging is used.
+    verbose: # (default: false)
+  # `triton.ports` contains configuration options for the management of the Triton Distributed Worker exposed.
+  ports: # (optional)
+    # `triton.ports.data` is the container port exposed to enable Triton Distributed Worker data-plane operations.
+    data: # (default 9346)
+    # `triton.ports.health` is the container port exposed to enable Triton Distributed Worker Kubernetes health reporting.
+    health: # (default 8000)
+    # `triton.ports.metrics` is the container port exposed to enable Triton Distributed Worker metrics reporting.
+    metrics: # (default 9347)
+    # `triton.ports.request` is the container port exposed to enable Triton Distributed Worker request-plane operations.
+    request: # (default 9345)
+  # `triton.resources` contains configuration options related to the resources assigned to Triton Distributed Worker and loaded model(s).
+  resources: # (optional)
+    # `triton.resources.cpu` is the number of logical CPU cores required by the Triton Distributed Worker and loaded model(s).
+    cpu: # (default: 4)
+    # `triton.resources.ephemeral` is the ephemeral storage (aka local disk usage) allowance.
+    # Ephemeral storage MUST include any shared memory allocated to Triton Distributed Worker.
+    # Value must be provided in Kubernetes' unit notation.
+    ephemeral: # (default: 1Gi)
+    # `triton.resources.gpu` contains configuration options related GPU resources to be assigned to the Triton Distributed Worker and loaded model(s).
+    gpu: # (optional)
+      # `triton.resources.gpu.count` specifies the number of GPUs required by the Triton Distributed Worker and loaded model(s).
+      count: # (default: 1)
+      # `triton.resources.gpu.product` defines list of the supported GPUs to which Triton Distributed Worker instance(s) can be deployed.
+      # Value must match the node's `.metadata.labels.nvidia.com/gpu.product` label provided by the NVIDIA GPU Discovery Service.
+      # Run 'kubectl get nodes' to find node names.
+      # Run 'kubectl describe node <node_name>' to inspect a node's labels.
+      product: [] # (optional)
+    # `triton.resources.memory` specifies the amount of CPU visible (aka host) memory available to the Triton Distributed Worker and loaded model(s).
+    # Value must be provided in Kubernetes' unit notation.
+    memory: # (default: 16Gi)
+    # `triton.resources.sharedMemory` specifies about amount of shared CPU visible (aka host) memory available the Triton Distributed Worker and loaded model(s).
+    # Value must be provided in Kubernetes' unit notation.
+    sharedMemory: # (default: 512Mi)

--- a/deploy/Kubernetes/worker/tests/trtllm/bad_volume_mounts.yaml
+++ b/deploy/Kubernetes/worker/tests/trtllm/bad_volume_mounts.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+modelRepository:
+  volumeMounts:
+  - name: mount_w_path
+    path: subpath

--- a/deploy/Kubernetes/worker/tests/trtllm/basic_values.yaml
+++ b/deploy/Kubernetes/worker/tests/trtllm/basic_values.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+image:
+  name: "some_false-container_name:with_a-tag"
+
+triton:
+  componentName: faux-triton

--- a/deploy/Kubernetes/worker/tests/trtllm/host_cache.yaml
+++ b/deploy/Kubernetes/worker/tests/trtllm/host_cache.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+modelRepository:
+  modelGeneration:
+    hostCache:
+      enabled: true
+    sizeLimit: 200Gi

--- a/deploy/Kubernetes/worker/tests/trtllm/non_host_cache.yaml
+++ b/deploy/Kubernetes/worker/tests/trtllm/non_host_cache.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+modelRepository:
+  modelGeneration:
+    sizeLimit: 200Gi

--- a/deploy/Kubernetes/worker/tests/trtllm/test-chart.ps1
+++ b/deploy/Kubernetes/worker/tests/trtllm/test-chart.ps1
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set-strictmode -version latest
+
+. "$(& git rev-parse --show-toplevel)/deploy/Kubernetes/_build/helm-test.ps1"
+
+$is_debug = $false
+
+for ($i = 0 ; $i -lt $args.count ; $i += 1) {
+  $arg = $args[$i]
+  if ('--debug' -ieq $arg) {
+    $is_debug = $true
+  }
+  elseif (('--verbose' -ieq $arg) -or ('-v' -ieq $arg)) {
+    set_verbosity('DETAILED')
+  }
+  else {
+    fatal-exit "Unknown option '${arg}'."
+  }
+}
+
+$is_debug = $is_debug -or $(is_debug)
+if ($is_debug) {
+  $DebugPreference = 'Continue'
+}
+else {
+  $DebugPreference = 'SilentlyContinue'
+}
+
+$tests = @(
+    @{
+      name = 'worker/trtllm/basic'
+      expected = 0
+      matches = @(
+          'helm.sh/chart: "triton-distributed_worker-trtllm"[\n\r]{1,2}'
+          'app.kubernetes.io/instance: test[\n\r]{1,2}'
+          'app.kubernetes.io/name: faux-triton[\n\r]{1,2}'
+          '- TRITON_MODEL_REPOSITORY: "/var/run/models"[\n\r]{1,2}'
+          '- TRITON_MODEL_GENERATION_PATH: "/var/run/trtllm"[\n\r]{1,2}'
+          'image: some_false-container_name:with_a-tag[\n\r]{1,2}'
+          'ephemeral-storage: 98Gi[\n\r]{1,2}'
+        )
+      options = @()
+      values = @('basic_values.yaml')
+    }
+    @{
+      name = 'worker/trtllm/basic_error'
+      expected = 1
+      matches = @(
+          '- triton: componentName is required[\n\r]{1,2}'
+          'image: name is required'
+        )
+      options = @()
+      values = @()
+    }
+    @{
+      name = 'worker/trtllm/volume_mounts'
+      expected = 0
+      matches = @(
+          '- name: mount_w_path[\n\r ]+persistentVolumeClaim:[\n\r ]+claimName: w_path_pvc[\n\r]{1,2}'
+          '- name: mount_wo_path[\n\r ]+persistentVolumeClaim:[\n\r ]+claimName: wo_path_pvc[\n\r]{1,2}'
+          '- mountPath: \/var\/run\/models\/subpath[\n\r ]+name: mount_w_path[\r\n]{1,2}'
+          '- mountPath: \/var\/run\/models[\n\r ]+name: mount_wo_path[\n\r]{1,2}'
+        )
+      options = @()
+      values = @(
+          'basic_values.yaml'
+          'volume_mounts.yaml'
+        )
+    }
+    @{
+      name = 'worker/trtllm/bad_volume_mounts'
+      expected = 1
+      matches = @(
+          '- modelRepository.volumeMounts.0: persistentVolumeClaim is required'
+        )
+      options = @()
+      values = @(
+          'basic_values.yaml'
+          'bad_volume_mounts.yaml'
+        )
+    }
+    @{
+      name = 'worker/trtllm/host_cache'
+      expected = 0
+      matches = @(
+          'ephemeral-storage: 2Gi[\n\r]{1,2}'
+          '- name: model-host-cache[\n\r ]+hostPath:[\n\r ]+path: /triton/trtllm-cache[\n\r ]+type: DirectoryOrCreate[\n\r]{1,2}'
+          '- TRITON_MODEL_GENERATION_QUOTA: "200Gi"[\n\r]{1,2}'
+        )
+      options = @()
+      values = @(
+          'basic_values.yaml'
+          'host_cache.yaml'
+        )
+    }
+    @{
+      name = 'worker/trtllm/host_cache'
+      expected = 0
+      matches = @(
+          'ephemeral-storage: 202Gi[\n\r]{1,2}'
+          '- name: model-host-cache[\n\r ]+emptyDir:[\n\r ]+sizeLimit: 200Gi[\n\r]{1,2}'
+          '- TRITON_MODEL_GENERATION_QUOTA: "200Gi"[\n\r]{1,2}'
+        )
+      options = @()
+      values = @(
+          'basic_values.yaml'
+          'non_host_cache.yaml'
+        )
+    }
+  )
+
+try {
+  test_helm_chart 'deploy/Kubernetes/worker/charts/trtllm' 'deploy/Kubernetes/worker/tests/trtllm' $tests
+}
+catch {
+  if ($is_debug) {
+    throw $_
+  }
+
+  fatal_exit "$_"
+}
+
+# Clean up any NVBUILD environment variables left behind by the build.
+cleanup_after

--- a/deploy/Kubernetes/worker/tests/trtllm/volume_mounts.yaml
+++ b/deploy/Kubernetes/worker/tests/trtllm/volume_mounts.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+modelRepository:
+  volumeMounts:
+  - name: mount_w_path
+    path: subpath
+    persistentVolumeClaim: w_path_pvc
+  - name: mount_wo_path
+    persistentVolumeClaim: wo_path_pvc


### PR DESCRIPTION
This change add a basic solution for validation testing helm charts.

This change includes initial set of tests for the TRTLLM worker chart.

This change fixes several minor issues found in the TRTLLM worker chart using the new testing solution.

DLIS-7837

(request currently targets jwyman/helm-chart-3 branch and not main)