### PR TITLE
Increase timeouts on failing tests

### DIFF
--- a/worker/tests/python/integration/test_add_multiply_divide.py
+++ b/worker/tests/python/integration/test_add_multiply_divide.py
@@ -215,7 +215,7 @@ def run(num_requests, store_inputs_in_request=False):
     "(not os.path.exists('/usr/local/bin/nats-server'))",
     reason="NATS.io not present",
 )
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     ["store_inputs_in_request", "store_outputs_in_response"],
     [(False, False), (True, True)],

--- a/worker/tests/python/integration/test_consolidated_logging.py
+++ b/worker/tests/python/integration/test_consolidated_logging.py
@@ -208,7 +208,7 @@ def run(num_requests):
     "(not os.path.exists('/usr/local/bin/nats-server'))",
     reason="NATS.io not present",
 )
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     "consolidate_logs",
     [True, False],


### PR DESCRIPTION
#### What does the PR do?
`test_consolidated_logging` and `test_add_multiply_divide` keep failing because the timeouts are set too low. 
Increase timeouts on these tests.
