### PR TITLE
fix: Fix disaggregated TRTLLM inference

### DIFF
--- a/examples/llm/api_server/chat.py
+++ b/examples/llm/api_server/chat.py
@@ -128,6 +128,13 @@ def create_chat_response(
     # Extract prompt from detokenized_outputs
     cleaned_outputs = []
     for detokenized_output in detokenized_outputs:
+        # FIXME - should be receiving array of strings by this point, not nested arrays
+        if isinstance(detokenized_output, np.ndarray):
+            detokenized_output = str(detokenized_output[0])
+
+        if not isinstance(detokenized_output, str):
+            raise RuntimeError(f"ERROR: detokenized_output is not a string! {type(detokenized_output)=} | {detokenized_output=}")
+
         # FIXME: Should this be handled by 'echo' param instead?
         if detokenized_output.startswith(prompt):
             cleaned_output = detokenized_output[len(prompt) :]

--- a/examples/llm/api_server/remote_model_connector.py
+++ b/examples/llm/api_server/remote_model_connector.py
@@ -146,8 +146,6 @@ class RemoteModelConnector(BaseTriton3Connector):
             async for response in responses:
                 for output_name, value in response.outputs.items():
                     try:
-                        print("here4", flush=True)
-                        print("here", value, flush=True)
                         if value.data_type == DataType.BYTES:
                             numpy_tensor = [value.to_string_array()]
                         else:
@@ -158,7 +156,6 @@ class RemoteModelConnector(BaseTriton3Connector):
                         # is released after connection is closed.
                         # value.__del__()
                         pass
-                    print("here", numpy_tensor, flush=True)
                     outputs[output_name] = numpy_tensor
                 infer_response = InferenceResponse(
                     outputs=outputs,

--- a/examples/llm/tensorrtllm/deploy/launch_workers.py
+++ b/examples/llm/tensorrtllm/deploy/launch_workers.py
@@ -15,6 +15,7 @@
 
 import os
 import signal
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -43,16 +44,17 @@ for sig in signals:
 
 def _launch_mpi_workers(args):
     if args.context_worker_count == 1 or args.generate_worker_count == 1:
-        WORKER_LOG_DIR = str(Path(args.log_dir) / "workers")
         command = [
             "mpiexec",
             "--allow-run-as-root",
             "--oversubscribe",
-            "--output-filename",
-            WORKER_LOG_DIR,
             "--display-map",
             "--verbose",
         ]
+
+        if args.log_dir:
+            WORKER_LOG_DIR = str(Path(args.log_dir) / "workers")
+            command += ["--output-filename", WORKER_LOG_DIR]
 
         aggregate_gpus = args.context_worker_count + args.generate_worker_count
 
@@ -108,20 +110,23 @@ def _launch_workers(args):
 
 
 def _context_cmd(args, starting_gpu):
+    # Hard-coded worker name for internal communication,
+    # see tensorrtllm.deploy script
+    worker_name = "context"
     command = [
         "-np",
         "1",
         # FIXME: May need to double check this CUDA_VISIBLE_DEVICES
         # and trtllm gpu_device_id/participant_id interaction
-        "-x",
-        f"CUDA_VISIBLE_DEVICES={starting_gpu}",
+        #"-x",
+        #f"CUDA_VISIBLE_DEVICES={starting_gpu}",
         "python3",
         "-m",
         "llm.tensorrtllm.deploy",
         "--context-worker-count",
         "1",
         "--worker-name",
-        "llama",
+        worker_name,
         "--initialize-request-plane",
         "--request-plane-uri",
         f"{os.getenv('HOSTNAME')}:{args.nats_port}",
@@ -131,20 +136,23 @@ def _context_cmd(args, starting_gpu):
 
 
 def _generate_cmd(args, starting_gpu):
+    # Hard-coded worker name for internal communication
+    # see tensorrtllm.deploy script
+    worker_name = "generate"
     command = [
         "-np",
         "1",
         # FIXME: May need to double check this CUDA_VISIBLE_DEVICES
         # and trtllm gpu_device_id/participant_id interaction
-        "-x",
-        f"CUDA_VISIBLE_DEVICES={starting_gpu}",
+        #"-x",
+        #f"CUDA_VISIBLE_DEVICES={starting_gpu}",
         "python3",
         "-m",
         "llm.tensorrtllm.deploy",
         "--generate-worker-count",
         "1",
         "--worker-name",
-        "llama",
+        worker_name,
         "--request-plane-uri",
         f"{os.getenv('HOSTNAME')}:{args.nats_port}",
     ]
@@ -153,12 +161,14 @@ def _generate_cmd(args, starting_gpu):
 
 
 def _disaggregated_serving_cmd(args, starting_gpu):
+    # NOTE: This worker gets the args --worker-name because it will
+    # receive the API-serving facing requests, and internally handle
+    # the disaggregation. So this worker name should match the one
+    # registered to the API Server.
     command = [
-        "-np",
-        "1",
-        "-x",
         # FIXME: Does this model need a GPU assigned to it?
-        f"CUDA_VISIBLE_DEVICES={starting_gpu}",
+        #"-x",
+        #f"CUDA_VISIBLE_DEVICES={starting_gpu}",
         "python3",
         "-m",
         "llm.tensorrtllm.deploy",
@@ -166,7 +176,7 @@ def _disaggregated_serving_cmd(args, starting_gpu):
         "--starting-metrics-port",
         "50002",
         "--worker-name",
-        "llama",
+        args.worker_name,
         "--request-plane-uri",
         f"{os.getenv('HOSTNAME')}:{args.nats_port}",
     ]
@@ -174,12 +184,19 @@ def _disaggregated_serving_cmd(args, starting_gpu):
     return command
 
 
-def _launch_nats_server(args):
+def _launch_nats_server(args, clear_store=True):
+    # FIXME: Use NatsServer object defined in icp package
+    store_dir = "/tmp/nats_store"
+    if clear_store:
+        shutil.rmtree(store_dir, ignore_errors=True)
+
     command = [
         "/usr/local/bin/nats-server",
         "--jetstream",
         "--port",
         str(args.nats_port),
+        "--store_dir",
+        store_dir
     ]
 
     print(" ".join(command))


### PR DESCRIPTION
Fixes
- Fix launch of disaggregated_serving model in launch_workers script (typo in command after removing it from mpiexec)
- Add flushing of store_dir
- Fix string/numpy array handling in API server

Remaining work:
- IMPORTANT: Document / automate using that env var `export TRTLLM_USE_MPI_KVCACHE=1` (not in current code, added manually in shell)
- IMPORTANT: Cleanup FIXMEs and CUDA_VISIBLE_DEVICES / device setting logic (make sure when running the example that context/generate engines are loaded on separate GPUs)