### PR TITLE
ci: restrict which branches & paths trigging lab testing

### DIFF
--- a/.github/workflows/trigger_ci_pull.yml
+++ b/.github/workflows/trigger_ci_pull.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+name: NVIDIA Test Lab (pull) Validation
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/trigger_ci_push.yml
+++ b/.github/workflows/trigger_ci_push.yml
@@ -13,13 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+name: NVIDIA Test Lab (push) Validation
+
 on:
   push:
     branches:
     - 'main'
-    - 'r*'
     paths-ignore:
-    - deploy/Kubernetes/**
+    - 'deploy/Kubernetes/**'
+
 jobs:
   mirror_repo:
     environment: GITLAB


### PR DESCRIPTION
This change adds filters to both pull and push automation scripts that limit when work will sent to the NVIDIA Test Lab based on the target branch of and paths modified by a pull request.

This should help prevent unnecessary work from being sent to lab machines.
