### PR TITLE
Update trigger_ci_pull.yml

### DIFF
--- a/.github/workflows/trigger_ci_pull.yml
+++ b/.github/workflows/trigger_ci_pull.yml
@@ -15,7 +15,9 @@
 
 on:
   pull_request:
-
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
 jobs:
   mirror_repo:
     environment: GITLAB


### PR DESCRIPTION
This change skips Internal CI to run on changes to the following files

Any file under .github/ directory
README.md file at the root directory