### PR TITLE
fix: Set default 'latest' tag if git tags fail to get parsed

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -27,6 +27,10 @@ current_tag=$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || t
 
 # Get latest TAG and add COMMIT_ID for dev
 latest_tag=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1 main) | sed 's/^v//') || true
+if [[ -z ${latest_tag} ]]; then
+    latest_tag="0.0.1"
+    echo "No git release tag found, setting to unknown version: ${latest_tag}"
+fi
 
 # Use tag if available, otherwise use latest_tag.dev.commit_id
 VERSION=v${current_tag:-$latest_tag.dev.$commit_id}


### PR DESCRIPTION
Adds fallback logic to set `latest_tag=0.0.1` if git tags aren't found for whatever reason, which would previously lead to an error with the SCM version during pip install:
```
fatal: No names found, cannot describe anything.
...

PYTHON_PACKAGE_VERSION=.dev+6c62884

...

packaging.version.InvalidVersion: Invalid version: '.dev+6c62884'
```