### PR TITLE
ci: Remove conflicting paths-ignore from rust action

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -27,8 +27,6 @@ on:
     - main
     paths:
     - 'runtime/rust/**'
-    paths-ignore:
-    - deploy/Kubernetes/**
 
 jobs:
   pre-merge-rust:


### PR DESCRIPTION
Fixes failures like this: https://github.com/triton-inference-server/triton_distributed/actions/runs/13171148554/workflow

``` 
GitHub Actions
/ .github/workflows/pre-merge-rust.yml
Invalid workflow file

you may only define one of `paths` and `paths-ignore` for a single event
```

Shouldn't need to exclude kubernetes directory changes here since it is already specific to changes made in rust directory