### PR TITLE
doc: Fix doc links

### DIFF
--- a/runtime/rust/src/component.rs
+++ b/runtime/rust/src/component.rs
@@ -15,14 +15,14 @@
 
 //! The [Component] module defines the top-level API for building distributed applications.
 //!
-//! A distributed application consists of a set of [Component][Component] that can host one
-//! or more [Endpoint][Endpoint]. Each [Endpoint][Endpoint] is a network-accessible service
-//! that can be accessed by other [Component][Component] in the distributed application.
+//! A distributed application consists of a set of [Component] that can host one
+//! or more [Endpoint]. Each [Endpoint] is a network-accessible service
+//! that can be accessed by other [Component] in the distributed application.
 //!
 //! A [Component] is made discoverable by registering it with the distributed runtime under
 //! a [`Namespace`].
 //!
-//! A [`Namespace`] is a logical grouping of [Component][Component] that are grouped together.
+//! A [`Namespace`] is a logical grouping of [Component] that are grouped together.
 //!
 //! We might extend namespace to include grouping behavior, which would define groups of
 //! components that are tightly coupled.
@@ -35,7 +35,7 @@
 //! which define how that component was constructed/configured and what capabilities it can
 //! provide.
 //!
-//! Other [Component][Component] can write to watching locations within a [Component] etcd
+//! Other [Component] can write to watching locations within a [Component] etcd
 //! path. This allows the [Component] to take dynamic actions depending on the watch
 //! triggers.
 //!
@@ -85,8 +85,8 @@ pub struct ComponentEndpointInfo {
 }
 
 /// A [Component] a discoverable entity in the distributed runtime.
-/// You can host [Endpoint][Endpoint] on a [Component] by first creating
-/// a [Service] then adding one or more [Endpoint][Endpoint] to the [Service].
+/// You can host [Endpoint] on a [Component] by first creating
+/// a [Service] then adding one or more [Endpoint] to the [Service].
 ///
 /// You can also issue a request to a [Component]'s [Endpoint] by creating a [Client].
 #[derive(Educe, Builder, Clone)]
@@ -130,8 +130,10 @@ impl Component {
         unimplemented!("endpoints")
     }
 
+    /// TODO
+    ///
     /// This method will scrape the stats for all available services
-    /// Returns a stream of [`ServiceInfo`] objects.
+    /// Returns a stream of `ServiceInfo` objects.
     /// This should be consumed by a `[tokio::time::timeout_at`] because each services
     /// will only respond once, but there is no way to know when all services have responded.
     pub async fn stats_stream(&self) -> Result<()> {

--- a/runtime/rust/src/discovery.rs
+++ b/runtime/rust/src/discovery.rs
@@ -44,7 +44,7 @@ impl DiscoveryClient {
     }
 
     /// Create a [`Lease`] with a given time-to-live (TTL).
-    /// This [`Lease`] will be tied to the [`Runtime`], but has its own independent [`crate::CancellationToken`].
+    /// This [`Lease`] will be tied to the [`crate::Runtime`], but has its own independent [`crate::CancellationToken`].
     pub async fn create_lease(&self, ttl: i64) -> Result<Lease> {
         self.etcd_client.create_lease(ttl).await
     }

--- a/runtime/rust/src/pipeline/context.rs
+++ b/runtime/rust/src/pipeline/context.rs
@@ -17,7 +17,7 @@
 //! There are two context object defined in this module:
 //!
 //! - [`Context`] is an input context which is propagated through the processing pipeline,
-//!    up to the point where the input is pass to an [`triton_distributed::engine::AsyncEngine`] for processing.
+//!    up to the point where the input is pass to an [`crate::engine::AsyncEngine`] for processing.
 //! - [`StreamContext`] is the input context transformed into to a type erased context that maintains the inputs
 //!   registry and visitors. `StreamAdaptors` will amend themselves to the [`StreamContext`] to allow for the
 

--- a/runtime/rust/src/pipeline/network.rs
+++ b/runtime/rust/src/pipeline/network.rs
@@ -105,11 +105,7 @@ impl PendingConnections {
 }
 
 /// A [`ResponseService`] implements a services in which a context a specific subject with will
-/// be associated with a stream of responses. The key difference between a [`ResponseService`]
-/// and a [`RequestService`] is that the [`ResponseService`] is the awaits an explicit connection
-/// to be established, where as a [`RequestService`] has no known knowledge about incoming
-/// connections. All [`ResponseService`] connections are expected, all [`RequestService`] connections
-/// are unexpected.
+/// be associated with a stream of responses.
 #[async_trait::async_trait]
 pub trait ResponseService {
     async fn register(&self, options: StreamOptions) -> PendingConnections;

--- a/runtime/rust/src/pipeline/network/tcp/server.rs
+++ b/runtime/rust/src/pipeline/network/tcp/server.rs
@@ -61,13 +61,9 @@ impl ServerOptions {
     }
 }
 
-// todo - rename TcpResponseServer
-// we may need to disambiguate this and a TcpRequestServer
-
 /// A [`TcpStreamServer`] is a TCP service that listens on a port for incoming response connections.
 /// A Response connection is a connection that is established by a client with the intention of sending
-/// specific data back to the server. The key differentiating factor is that a [`ResponseServer`] is
-/// expecting a connection from a client with an established subject.
+/// specific data back to the server.
 pub struct TcpStreamServer {
     local_ip: String,
     local_port: u16,

--- a/runtime/rust/src/pipeline/nodes.rs
+++ b/runtime/rust/src/pipeline/nodes.rs
@@ -67,8 +67,7 @@ mod private {
 }
 
 // todo rename `ServicePipelineExt`
-/// A [`Source`] trait defines how data is emitted from a source to a downstream sink
-/// over an [`Edge`].
+/// A [`Source`] trait defines how data is emitted from a source to a downstream sink.
 #[async_trait]
 pub trait Source<T: PipelineIO>: Data {
     async fn on_next(&self, data: T, _: private::Token) -> Result<(), Error>;
@@ -88,7 +87,7 @@ pub trait Sink<T: PipelineIO>: Data {
     async fn on_data(&self, data: T, _: private::Token) -> Result<(), Error>;
 }
 
-/// An [`Edge`] is a connection between a [`Source`] and a [`Sink`]. Data flows over an [`Edge`].
+/// An [`Edge`] is a connection between a [`Source`] and a [`Sink`].
 pub struct Edge<T: PipelineIO> {
     downstream: Arc<dyn Sink<T>>,
 }

--- a/runtime/rust/src/runtime.rs
+++ b/runtime/rust/src/runtime.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The [Runtime] module is the interface for [crate::component::Component][crate::component::Component]
+//! The [Runtime] module is the interface for [crate::component::Component]
 //! to access shared resources. These include thread pool, memory allocators and other shared resources.
 //!
 //! The [Runtime] holds the primary [`CancellationToken`] which can be used to terminate all attached
-//! [crate::component::Component][crate::component::Component].
+//! [`crate::component::Component`].
 //!
 //! We expect in the future to offer topologically aware thread and memory resources, but for now the
 //! set of resources is limited to the thread pool and cancellation token.

--- a/runtime/rust/src/worker.rs
+++ b/runtime/rust/src/worker.rs
@@ -18,7 +18,7 @@
 //!
 //! In the future, the [Worker] should probably be moved to a procedural macro similar
 //! to the `#[tokio::main]` attribute, where we might annotate an async main function with
-//! #[triton::main] or similar.
+//! `#[triton::main]` or similar.
 //!
 //! The [Worker::execute] method is designed to be called once from main and will block
 //! the calling thread until the application completes or is canceled. The method initialized


### PR DESCRIPTION
`cargo doc` now runs without warnings.

