### PR TITLE
ci: Move slow pytests to nightly

### DIFF
--- a/runtime/tests/python/integration/test_mock_disaggregated_serving.py
+++ b/runtime/tests/python/integration/test_mock_disaggregated_serving.py
@@ -58,10 +58,8 @@ try:
 except CUDARuntimeError:
     print("CUDA not available")
 
-# TODO
-# Decide if this should be
-# pre merge, nightly, or weekly
-pytestmark = pytest.mark.pre_merge
+# Slower test than others - make it nightly for now
+pytestmark = pytest.mark.nightly
 
 
 @pytest.fixture

--- a/runtime/tests/python/integration/test_perf_benchmark.py
+++ b/runtime/tests/python/integration/test_perf_benchmark.py
@@ -36,10 +36,8 @@ TRITON_LOG_LEVEL = 0
 
 logger = get_logger(__name__)
 
-# TODO
-# Decide if this should be
-# pre merge, nightly, or weekly
-pytestmark = pytest.mark.pre_merge
+# Slower test than others - make it nightly for now
+pytestmark = pytest.mark.nightly
 
 
 @pytest.fixture


### PR DESCRIPTION
Marks slower mock_disagg and perf_benchmark tests to nightly instead of pre_merge.

This should cut down pytest time from ~5-10min to ~1-2min.

Corresponding gitlab PR to run nightly tests coming soon.