### PR TITLE
refactor: Handle JSON serialize / de-serialize errors.

### DIFF
--- a/runtime/rust/src/config.rs
+++ b/runtime/rust/src/config.rs
@@ -29,14 +29,15 @@ pub struct WorkerConfig {
 }
 
 impl WorkerConfig {
+    /// Instantiates and reads server configurations from appropriate sources.
+    /// Panics on invalid configuration.
     pub fn from_settings() -> Self {
-        // Instantiates and reads server configurations from appropriate sources.
         // All calls should be global and thread safe.
         Figment::new()
             .merge(Serialized::defaults(Self::default()))
             .merge(Env::prefixed("TRITON_WORKER_"))
             .extract()
-            .unwrap()
+            .unwrap() // safety: Called on startup, so panic is reasonable
     }
 }
 

--- a/runtime/rust/src/pipeline/network/ingress/push_handler.rs
+++ b/runtime/rust/src/pipeline/network/ingress/push_handler.rs
@@ -38,7 +38,15 @@ where
                     header.len(),
                     data.len()
                 );
-                let control_msg: RequestControlMessage = serde_json::from_slice(&header).unwrap();
+                let control_msg: RequestControlMessage = match serde_json::from_slice(&header) {
+                    Ok(cm) => cm,
+                    Err(err) => {
+                        let json_str = String::from_utf8_lossy(&header);
+                        return Err(PipelineError::DeserializationError(
+                            format!("Failed deserializing to RequestControlMessage. err={err}, json_str={json_str}"),
+                        ));
+                    }
+                };
                 let request: T = serde_json::from_slice(&data)?;
                 (control_msg, request)
             }

--- a/runtime/rust/src/pipeline/network/tcp/client.rs
+++ b/runtime/rust/src/pipeline/network/tcp/client.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 
 use futures::{SinkExt, StreamExt};
+use tokio::io::{ReadHalf, WriteHalf};
 use tokio::{io::AsyncWriteExt, net::TcpStream};
 use tokio_util::codec::{FramedRead, FramedWrite};
 
@@ -82,7 +83,7 @@ impl TcpClient {
         let stream = TcpClient::connect(&info.address).await?;
         let (read_half, write_half) = tokio::io::split(stream);
 
-        let mut framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
         let mut framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
 
         // this is a oneshot channel that will be used to signal when the stream is closed
@@ -90,53 +91,9 @@ impl TcpClient {
         // the forwarder task will capture the alive_rx half of the oneshot channel; this will close the alive channel
         // so the holder of the alive_tx half will be notified that the stream is closed; the alive_tx channel will be
         // captured by the monitor task
-        let (mut alive_tx, alive_rx) = tokio::sync::oneshot::channel::<()>();
+        let (alive_tx, alive_rx) = tokio::sync::oneshot::channel::<()>();
 
-        // monitors the channel for a cancellation signal
-        // this task exits when the alive_rx half of the oneshot channel is closed or a stop/kill signal is received
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    msg = framed_reader.next() => {
-                        match msg {
-                            Some(Ok(two_part_msg)) => {
-                                match two_part_msg.optional_parts() {
-                                   (Some(bytes), None) => {
-                                        let msg: ControlMessage = serde_json::from_slice(bytes).unwrap();
-                                        match msg {
-                                            ControlMessage::Stop => {
-                                                context.stop();
-                                                break;
-                                            }
-                                            ControlMessage::Kill => {
-                                                context.kill();
-                                                break;
-                                            }
-                                        }
-                                   }
-                                   _ => {
-                                       // we should not receive this
-                                   }
-                                }
-                            }
-                            Some(Err(e)) => {
-                                panic!("failed to decode message from stream: {:?}", e);
-                                // break;
-                            }
-                            None => {
-                                // the stream was closed, we should stop the stream
-                                return;
-                            }
-                        }
-                    }
-                    _ = alive_tx.closed() => {
-                        // the channel was closed, we should stop the stream
-                        break;
-                    }
-                }
-            }
-            // framed_writer.get_mut().shutdown().await.unwrap();
-        });
+        tokio::spawn(control_handler(framed_reader, context, alive_tx));
 
         // transport specific handshake message
         let handshake = CallHomeHandshake {
@@ -144,7 +101,14 @@ impl TcpClient {
             stream_type: StreamType::Response,
         };
 
-        let handshake_bytes = serde_json::to_vec(&handshake).unwrap();
+        let handshake_bytes = match serde_json::to_vec(&handshake) {
+            Ok(hb) => hb,
+            Err(err) => {
+                return Err(format!(
+                    "create_response_steam: Error converting CallHomeHandshake to JSON array: {err:#}"
+                ));
+            }
+        };
         let msg = TwoPartMessage::from_header(handshake_bytes.into());
 
         // issue the the first tcp handshake message
@@ -154,26 +118,10 @@ impl TcpClient {
             .map_err(|e| format!("failed to send handshake: {:?}", e))?;
 
         // set up the channel to send bytes to the transport layer
-        let (bytes_tx, mut bytes_rx) = tokio::sync::mpsc::channel(16);
+        let (bytes_tx, bytes_rx) = tokio::sync::mpsc::channel(16);
 
         // forwards the bytes send from this stream to the transport layer; hold the alive_rx half of the oneshot channel
-        tokio::spawn(async move {
-            while let Some(msg) = bytes_rx.recv().await {
-                if let Err(e) = framed_writer.send(msg).await {
-                    tracing::trace!(
-                        "failed to send message to stream; possible disconnect: {:?}",
-                        e
-                    );
-
-                    // TODO - possibly propagate the error upstream
-                    break;
-                }
-            }
-            drop(alive_rx);
-            if let Err(e) = framed_writer.get_mut().shutdown().await {
-                tracing::trace!("failed to shutdown writer: {:?}", e);
-            }
-        });
+        tokio::spawn(forward_handler(bytes_rx, framed_writer, alive_rx));
 
         // set up the prologue for the stream
         // this might have transport specific metadata in the future
@@ -186,5 +134,82 @@ impl TcpClient {
         };
 
         Ok(stream_sender)
+    }
+}
+
+/// monitors the channel for a cancellation signal
+/// this task exits when the alive_rx half of the oneshot channel is closed or a stop/kill signal is received
+async fn control_handler(
+    mut framed_reader: FramedRead<ReadHalf<TcpStream>, TwoPartCodec>,
+    context: Arc<dyn AsyncEngineContext>,
+    mut alive_tx: tokio::sync::oneshot::Sender<()>,
+) {
+    loop {
+        tokio::select! {
+            msg = framed_reader.next() => {
+                match msg {
+                    Some(Ok(two_part_msg)) => {
+                        match two_part_msg.optional_parts() {
+                           (Some(bytes), None) => {
+                                let msg: ControlMessage = match serde_json::from_slice(bytes) {
+                                    Ok(msg) => msg,
+                                    Err(err) => {
+                                        let json_str = String::from_utf8_lossy(bytes);
+                                        tracing::error!(%err, %json_str, "control_handler fatal error deserializing JSON to ControlMessage");
+                                        context.kill();
+                                        break;
+                                    }
+                                };
+                                match msg {
+                                    ControlMessage::Stop => {
+                                        context.stop();
+                                        break;
+                                    }
+                                    ControlMessage::Kill => {
+                                        context.kill();
+                                        break;
+                                    }
+                                }
+                           }
+                           _ => {
+                               // we should not receive this
+                           }
+                        }
+                    }
+                    Some(Err(e)) => {
+                        panic!("failed to decode message from stream: {:?}", e);
+                        // break;
+                    }
+                    None => {
+                        // the stream was closed, we should stop the stream
+                        return;
+                    }
+                }
+            }
+            _ = alive_tx.closed() => {
+                // the channel was closed, we should stop the stream
+                break;
+            }
+        }
+    }
+    // framed_writer.get_mut().shutdown().await.unwrap();
+}
+
+async fn forward_handler(
+    mut bytes_rx: tokio::sync::mpsc::Receiver<TwoPartMessage>,
+    mut framed_writer: FramedWrite<WriteHalf<TcpStream>, TwoPartCodec>,
+    alive_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    while let Some(msg) = bytes_rx.recv().await {
+        if let Err(e) = framed_writer.send(msg).await {
+            tracing::trace!(%e, "failed to send message to stream; possible disconnect");
+
+            // TODO - possibly propagate the error upstream
+            break;
+        }
+    }
+    drop(alive_rx);
+    if let Err(e) = framed_writer.get_mut().shutdown().await {
+        tracing::trace!("failed to shutdown writer: {:?}", e);
     }
 }


### PR DESCRIPTION
Replace `unwrap()` with error handling at the interface between JSON and Rust; where weak typing becomes strong typing.