### PR TITLE
chore: Again: Add rust-toolchain so we're all on the same version

### DIFF
--- a/llm/rust/rust-toolchain.toml
+++ b/llm/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.1"

--- a/runtime/rust/examples/hello_world/Cargo.lock
+++ b/runtime/rust/examples/hello_world/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "env_logger",
  "triton-distributed",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "triton-distributed"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/runtime/rust/examples/hello_world/rust-toolchain.toml
+++ b/runtime/rust/examples/hello_world/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.1"

--- a/runtime/rust/python-wheel/rust-toolchain.toml
+++ b/runtime/rust/python-wheel/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.1"

--- a/runtime/rust/rust-toolchain.toml
+++ b/runtime/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.1"


### PR DESCRIPTION
A repeat of https://github.com/triton-inference-server/triton_distributed/pull/145 that was accidentally reverted in https://github.com/triton-inference-server/triton_distributed/pull/123
