### PR TITLE
fix: Fix rust pre-merge for new tio directory

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -55,7 +55,7 @@ jobs:
       working-directory: runtime/rust
       run: cargo check --locked
     - name: Run Cargo Check on tio
-      working-directory: apps/tio
+      working-directory: applications/llm/bin/tio
       run: cargo check --locked
     - name: Verify Code Formatting
       working-directory: runtime/rust
@@ -64,7 +64,7 @@ jobs:
       working-directory: runtime/rust
       run: cargo clippy --no-deps --all-targets -- -D warnings
     - name: Run Clippy Checks on tio
-      working-directory: apps/tio
+      working-directory: applications/llm/bin/tio
       run: cargo clippy --no-deps --all-targets -- -D warnings
     - name: Install and Run cargo-deny
       working-directory: runtime/rust

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -27,6 +27,11 @@ on:
     - main
     paths:
     - 'runtime/rust/**'
+    - 'llm/rust/**'
+    - 'applications/llm/bin/tio/**'
+    - '**.rs'
+    - 'Cargo.toml'
+    - 'Cargo.lock'
 
 jobs:
   pre-merge-rust:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea
 .vs/
 .vscode/
-[Bb][Ii][Nn]/
 [Bb]inlog/
 [Bb][Uu][Ii][Ll][Dd]/
 [Cc][Mm][Aa][Kk][Ee]/
@@ -11,7 +10,6 @@
 
 **/.idea
 **/.vscode/
-**/[Bb][Ii][Nn]/
 **/[Bb]inlog/
 **/[Dd]ebug/
 **/[Oo][Bb][Jj]/


### PR DESCRIPTION
Rust pre-merge check on source code for `tio` moved from `apps/tio` to `applications/llm/bin/tio` - so updating the check accordingly.

Should fix this error: https://github.com/triton-inference-server/triton_distributed/actions/runs/13318456550/job/37198020744