### PR TITLE
refactor: Remove secondary runtime and lease

### DIFF
--- a/applications/llm/bin/tio/src/main.rs
+++ b/applications/llm/bin/tio/src/main.rs
@@ -81,11 +81,5 @@ async fn tio_wrapper(runtime: triton_distributed::Runtime) -> anyhow::Result<()>
     // Wraps the Runtime (which wraps two tokio runtimes) and adds etcd and nats clients
     let d_runtime = triton_distributed::DistributedRuntime::new(runtime, dt_config).await?;
 
-    tio::run(
-        in_opt,
-        out_opt,
-        nio_flags,
-        d_runtime.runtime().primary_token(),
-    )
-    .await
+    tio::run(in_opt, out_opt, nio_flags, d_runtime.runtime().token()).await
 }

--- a/runtime/rust/src/component/endpoint.rs
+++ b/runtime/rust/src/component/endpoint.rs
@@ -41,7 +41,7 @@ impl EndpointConfigBuilder {
 
     pub async fn start(self) -> Result<()> {
         let (endpoint, lease, handler) = self.build_internal()?.dissolve();
-        let lease = lease.unwrap_or(endpoint.component.drt.primary_lease());
+        let lease = lease.unwrap_or(endpoint.component.drt.lease());
 
         tracing::debug!(
             "Starting endpoint: {}",
@@ -75,7 +75,7 @@ impl EndpointConfigBuilder {
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to build push endpoint: {e}"))?;
 
-        // launch in primary runtime
+        // launch!
         let task = tokio::spawn(push_endpoint.start(service_endpoint));
 
         // tracing::debug!(worker_id, "endpoint subject: {}", subject);

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -55,8 +55,7 @@ enum RuntimeType {
 #[derive(Debug, Clone)]
 pub struct Runtime {
     id: Arc<String>,
-    primary: RuntimeType,
-    secondary: Arc<tokio::runtime::Runtime>,
+    tokio_runtime: RuntimeType,
     cancellation_token: CancellationToken,
 }
 


### PR DESCRIPTION
Why remove it?

- It makes the system easier to understand. There's a single tokio runtime which the user can (and should) provide, and there's a single etcd lease.

- It gives control of the Tokio runtime back to the user. I can make a primary runtime with Runtime::from_handle, but the secondary runtime creation is hard coded in Runtime::new. I don't think runtime creation belongs in a library like this.

- It makes debugging easier. Two runtimes is something almost no-one else does. For example to use tokio-console this would need two console-subscriber.

- The second one doesn't help. Blocking either runtime is going to be fatal. We will prevent that with an integration test on a single threaded runtime (default #[tokio::test]).

Closes https://github.com/triton-inference-server/triton_distributed/issues/139
