### PR TITLE
ci: Add Biswa and Thomas as Rust reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,10 +4,10 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Rust
-*.rs @ryanolson @grahamking @paulhendricks
-/runtime/rust/ @ryanolson @grahamking @paulhendricks
-/llm/rust/ @ryanolson @grahamking @paulhendricks
-Cargo.toml @ryanolson @grahamking @paulhendricks
+*.rs @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12
+/runtime/rust/ @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12
+/llm/rust/ @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12
+Cargo.toml @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12
 
 # Python Libraries
 /runtime/python/ @nnshah1 @tanmayv25 @piotrm-nvidia @ptarasiewiczNV @nv-blazejkubiak


### PR DESCRIPTION
We are bottle-necked on Rust code review. Expand.