### PR TITLE
refactor: adds `TryFrom<&str>` and `FromStr` for `Endpoint`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vs/
 .vscode/
+.helix
 [Bb]inlog/
 [Bb][Uu][Ii][Ll][Dd]/
 [Cc][Mm][Aa][Kk][Ee]/

--- a/applications/llm/tio/src/input/endpoint.rs
+++ b/applications/llm/tio/src/input/endpoint.rs
@@ -38,18 +38,8 @@ pub async fn run(
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
 
     let cancel_token = runtime.primary_token().clone();
-    let elements: Vec<&str> = path.split('/').collect();
-    if elements.len() != 3 {
-        anyhow::bail!(
-            "An endpoint URL must have format {ENDPOINT_SCHEME}namespace/component/endpoint"
-        );
-    }
+    let endpoint: Endpoint = path.parse()?;
 
-    let endpoint = Endpoint {
-        namespace: elements[0].to_string(),
-        component: elements[1].to_string(),
-        name: elements[2].to_string(),
-    };
     let etcd_client = distributed.etcd_client();
 
     let (ingress, service_name) = match engine_config {
@@ -89,7 +79,7 @@ pub async fn run(
 
     let model_registration = ModelEntry {
         name: service_name.to_string(),
-        endpoint,
+        endpoint: endpoint.clone(),
     };
     etcd_client
         .kv_create(
@@ -100,12 +90,12 @@ pub async fn run(
         .await?;
 
     let rt_fut = distributed
-        .namespace(elements[0])?
-        .component(elements[1])?
+        .namespace(endpoint.namespace)?
+        .component(endpoint.component)?
         .service_builder()
         .create()
         .await?
-        .endpoint(elements[2])
+        .endpoint(endpoint.name)
         .endpoint_builder()
         .handler(ingress)
         .start();

--- a/applications/llm/tio/src/lib.rs
+++ b/applications/llm/tio/src/lib.rs
@@ -15,13 +15,13 @@
 
 use std::path::PathBuf;
 
-use triton_distributed_runtime::{component::Client, DistributedRuntime};
 use triton_distributed_llm::types::{
     openai::chat_completions::{
         ChatCompletionRequest, ChatCompletionResponseDelta, OpenAIChatCompletionsStreamingEngine,
     },
     Annotated,
 };
+use triton_distributed_runtime::{component::Client, DistributedRuntime};
 
 mod input;
 mod opt;
@@ -138,7 +138,8 @@ pub async fn run(
             };
             EngineConfig::StaticFull {
                 service_name: model_name,
-                engine: triton_distributed_llm::engines::mistralrs::make_engine(&model_path).await?,
+                engine: triton_distributed_llm::engines::mistralrs::make_engine(&model_path)
+                    .await?,
             }
         }
     };

--- a/lib/runtime/src/pipeline/error.rs
+++ b/lib/runtime/src/pipeline/error.rs
@@ -87,6 +87,9 @@ pub enum PipelineError {
     #[error("Generate Error: {0}")]
     GenerateError(Error),
 
+    #[error("An endpoint URL must have the format: namespace/component/endpoint")]
+    InvalidEndpointFormat,
+
     #[error("NATS Request Error: {0}")]
     NatsRequestError(#[from] NatsError<async_nats::jetstream::context::RequestErrorKind>),
 


### PR DESCRIPTION
#### What does the PR do?
Adds `TryFrom<&str>` and `FromStr` for `Endpoint` as well as docs and tests.

Why? Refactors a bit. Documentation and tests are always good. But mainly want to make sure I have permissions to land a PR.

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [X] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [X] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [X] refactor
- [ ] revert
- [ ] style
- [X] test

#### Related PRs:
#235 

#### Where should the reviewer start?
`applications/llm/tio/src/input/endpoint.rs`

#### Test plan:
- Unit tests were added
- E2E tests not relevant

- CI Pipeline ID:
TBD

#### Caveats:
N/A

#### Background
Feedback in #235 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
Related to #235 
