### PR TITLE
fix: Make the CI codespell be a warning not a fatal error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,9 @@ repos:
     additional_dependencies: [tomli]
     args: ["--toml", "pyproject.toml"]
     exclude: (?x)^(.*stemmer.*|.*stop_words.*|^CHANGELOG.md$|.*lib/llm/tests/data.*)
+    always_run: true
+    verbose: true
+    stage: [warn]
 
 # More details about these pre-commit hooks here:
 # https://pre-commit.com/hooks.html


### PR DESCRIPTION
codespell is known to be broken. It won't accept any word with a quote: It won't don't can't work.

Nevertheless spell checking in comments and variables names is useful. Make it display the warning but not block merging.
