### PR TITLE
docs(vllm): update Docker Compose instructions in README

### DIFF
--- a/examples/python_rs/llm/vllm/README.md
+++ b/examples/python_rs/llm/vllm/README.md
@@ -23,9 +23,9 @@ This example demonstrates how to use Triton Distributed to serve large language 
 
 Start required services (etcd and NATS):
 
-   Option A: Using [Docker Compose](/runtime/rust/docker-compose.yml) (Recommended)
+   Option A: Using [Docker Compose](/deploy/docker-compose.yml) (Recommended)
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
    Option B: Manual Setup


### PR DESCRIPTION
DESCRIPTION:
## Overview
This PR updates the Docker Compose instructions in the vLLM README file to reflect the correct file path and command syntax.

## Detailed breakdown and reasoning
The changes are necessary to ensure users can correctly set up the required services (etcd and NATS) using Docker Compose. The updates provide more accurate information and align with current best practices.

## Changes Made
- Updated the Docker Compose file path from `/runtime/rust/docker-compose.yml` to `/deploy/docker-compose.yml`
- Changed the Docker Compose command from `docker-compose up -d` to `docker compose up -d` (removing the hyphen)

These updates will help users avoid potential confusion and ensure they can successfully set up the required services for the vLLM example.