### PR TITLE
chore: Remove 'Roff' section from repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@
 *.[Pp][Nn][Gg]      binary
 *.[Zz][Ii][Pp]      binary
 *.[Tt][Gg][Zz]      binary
+
+# Exclude test data files from linguist language detection
+lib/llm/tests/data/** linguist-vendored
+lib/llm/tests/snapshots/** linguist-vendored


### PR DESCRIPTION
Remove the strange `Roff` section from the language repo stats by excluding the test/data files from [Linguist](https://github.com/github-linguist/linguist/tree/main) detection: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md

![image](https://github.com/user-attachments/assets/15fe0a74-5760-4dca-a8fe-4a3761406577)
