### PR TITLE
CI: Add Label to PRs from external contributors

### DIFF
--- a/.github/workflows/external-pr.yml
+++ b/.github/workflows/external-pr.yml
@@ -1,0 +1,53 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: Label PRs from external contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  Label:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)}}
+    steps:
+      - name: Adding Label
+        uses: actions/github-script@v7
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CONTRIBUTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const { REPOSITORY, CONTRIBUTOR } = process.env
+
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["external-contribution"]
+            });


### PR DESCRIPTION
This workflow will only run when PRs are created by non-members and non-owners of the repos.

It will add a label to all PRs by external contributors.

<img width="417" alt="Screenshot 2025-02-26 at 11 29 50 PM" src="https://github.com/user-attachments/assets/e296a618-4adc-4906-bc4a-4ef84614300e" />

We want to filter PRs from external contributors and then send reminders to the repository CodeOwners to review -> Approve -> close those PRs in a timely manner.

<img width="522" alt="Screenshot 2025-02-26 at 11 23 29 PM" src="https://github.com/user-attachments/assets/77f3e744-b09a-4a9f-a7c0-eed5b5a55127" />

<img width="409" alt="Screenshot 2025-02-26 at 11 31 01 PM" src="https://github.com/user-attachments/assets/d3e69bf9-d0f9-4f7a-a8a0-ec8ee8409a8f" />
