### PR TITLE
refactor: rename ChatCompletionResponseDelta to NvCreateChatCompletionStreamResponse

### DIFF
--- a/launch/tio/src/input/endpoint.rs
+++ b/launch/tio/src/input/endpoint.rs
@@ -19,7 +19,9 @@ use triton_distributed_llm::{
     model_type::ModelType,
     preprocessor::OpenAIPreprocessor,
     types::{
-        openai::chat_completions::{ChatCompletionResponseDelta, NvCreateChatCompletionRequest},
+        openai::chat_completions::{
+            NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+        },
         Annotated,
     },
 };
@@ -55,7 +57,7 @@ pub async fn run(
         } => {
             let frontend = SegmentSource::<
                 SingleIn<NvCreateChatCompletionRequest>,
-                ManyOut<Annotated<ChatCompletionResponseDelta>>,
+                ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
             >::new();
             let preprocessor = OpenAIPreprocessor::new(*card.clone())
                 .await?

--- a/launch/tio/src/input/http.rs
+++ b/launch/tio/src/input/http.rs
@@ -21,7 +21,9 @@ use triton_distributed_llm::{
     model_type::ModelType,
     preprocessor::OpenAIPreprocessor,
     types::{
-        openai::chat_completions::{ChatCompletionResponseDelta, NvCreateChatCompletionRequest},
+        openai::chat_completions::{
+            NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+        },
         Annotated,
     },
 };
@@ -75,7 +77,7 @@ pub async fn run(
         } => {
             let frontend = ServiceFrontend::<
                 SingleIn<NvCreateChatCompletionRequest>,
-                ManyOut<Annotated<ChatCompletionResponseDelta>>,
+                ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
             >::new();
             let preprocessor = OpenAIPreprocessor::new(*card.clone())
                 .await?

--- a/launch/tio/src/input/text.rs
+++ b/launch/tio/src/input/text.rs
@@ -23,7 +23,7 @@ use triton_distributed_llm::{
     preprocessor::OpenAIPreprocessor,
     types::{
         openai::chat_completions::{
-            ChatCompletionResponseDelta, NvCreateChatCompletionRequest,
+            NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
             OpenAIChatCompletionsStreamingEngine,
         },
         Annotated,
@@ -72,7 +72,7 @@ pub async fn run(
         } => {
             let frontend = ServiceFrontend::<
                 SingleIn<NvCreateChatCompletionRequest>,
-                ManyOut<Annotated<ChatCompletionResponseDelta>>,
+                ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
             >::new();
             let preprocessor = OpenAIPreprocessor::new(*card.clone())
                 .await?

--- a/launch/tio/src/lib.rs
+++ b/launch/tio/src/lib.rs
@@ -21,7 +21,7 @@ use triton_distributed_llm::{
     model_card::model::ModelDeploymentCard,
     types::{
         openai::chat_completions::{
-            ChatCompletionResponseDelta, NvCreateChatCompletionRequest,
+            NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
             OpenAIChatCompletionsStreamingEngine,
         },
         Annotated,
@@ -113,7 +113,7 @@ pub struct Flags {
 pub enum EngineConfig {
     /// An remote networked engine we don't know about yet
     /// We don't have the pre-processor yet so this is only text requests. Type will change later.
-    Dynamic(Client<NvCreateChatCompletionRequest, Annotated<ChatCompletionResponseDelta>>),
+    Dynamic(Client<NvCreateChatCompletionRequest, Annotated<NvCreateChatCompletionStreamResponse>>),
 
     /// A Full service engine does it's own tokenization and prompt formatting.
     StaticFull {
@@ -223,7 +223,7 @@ pub async fn run(
                 .namespace(endpoint.namespace)?
                 .component(endpoint.component)?
                 .endpoint(endpoint.name)
-                .client::<NvCreateChatCompletionRequest, Annotated<ChatCompletionResponseDelta>>()
+                .client::<NvCreateChatCompletionRequest, Annotated<NvCreateChatCompletionStreamResponse>>()
                 .await?;
 
             tracing::info!("Waiting for remote {}...", client.path());

--- a/lib/llm/src/engines/mistralrs.rs
+++ b/lib/llm/src/engines/mistralrs.rs
@@ -34,7 +34,7 @@ use triton_distributed_runtime::pipeline::{Error, ManyOut, SingleIn};
 use triton_distributed_runtime::protocols::annotated::Annotated;
 
 use crate::protocols::openai::chat_completions::{
-    ChatCompletionRequest, ChatCompletionResponseDelta,
+    ChatCompletionRequest, NvCreateChatCompletionStreamResponse,
 };
 use crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine;
 
@@ -161,14 +161,14 @@ impl MistralRsEngine {
 impl
     AsyncEngine<
         SingleIn<ChatCompletionRequest>,
-        ManyOut<Annotated<ChatCompletionResponseDelta>>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
         Error,
     > for MistralRsEngine
 {
     async fn generate(
         &self,
         request: SingleIn<ChatCompletionRequest>,
-    ) -> Result<ManyOut<Annotated<ChatCompletionResponseDelta>>, Error> {
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
         let (request, context) = request.transfer(());
         let ctx = context.context();
         let (tx, mut rx) = channel(10_000);
@@ -286,7 +286,7 @@ impl
                             system_fingerprint: Some(c.system_fingerprint),
                             service_tier: None,
                         };
-                        let delta = ChatCompletionResponseDelta{inner};
+                        let delta = NvCreateChatCompletionStreamResponse{inner};
                         let ann = Annotated{
                             id: None,
                             data: Some(delta),

--- a/lib/llm/src/http/service/discovery.rs
+++ b/lib/llm/src/http/service/discovery.rs
@@ -28,7 +28,7 @@ use triton_distributed_runtime::{
 use super::ModelManager;
 use crate::model_type::ModelType;
 use crate::protocols::openai::chat_completions::{
-    ChatCompletionResponseDelta, NvCreateChatCompletionRequest,
+    NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
 };
 use crate::protocols::openai::completions::{CompletionRequest, CompletionResponse};
 use tracing;
@@ -135,7 +135,7 @@ async fn handle_put(kv: &KeyValue, state: Arc<ModelWatchState>) -> Result<(&str,
                 .namespace(model_entry.endpoint.namespace)?
                 .component(model_entry.endpoint.component)?
                 .endpoint(model_entry.endpoint.name)
-                .client::<NvCreateChatCompletionRequest, Annotated<ChatCompletionResponseDelta>>()
+                .client::<NvCreateChatCompletionRequest, Annotated<NvCreateChatCompletionStreamResponse>>()
                 .await?;
             state
                 .manager

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -44,7 +44,7 @@ use triton_distributed_runtime::protocols::annotated::{Annotated, AnnotationsPro
 use crate::protocols::{
     common::{SamplingOptionsProvider, StopConditionsProvider},
     openai::{
-        chat_completions::{ChatCompletionResponseDelta, NvCreateChatCompletionRequest},
+        chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
         completions::{CompletionRequest, CompletionResponse},
         nvext::NvExtProvider,
         DeltaGeneratorExt,
@@ -225,7 +225,7 @@ impl OpenAIPreprocessor {
 
                     tracing::trace!(
                         request_id = inner.context.id(),
-                        "OpenAI ChatCompletionResponseDelta: {:?}",
+                        "OpenAI NvCreateChatCompletionStreamResponse: {:?}",
                         response
                     );
 
@@ -252,7 +252,7 @@ impl OpenAIPreprocessor {
 impl
     Operator<
         SingleIn<NvCreateChatCompletionRequest>,
-        ManyOut<Annotated<ChatCompletionResponseDelta>>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
         SingleIn<BackendInput>,
         ManyOut<Annotated<BackendOutput>>,
     > for OpenAIPreprocessor
@@ -263,7 +263,7 @@ impl
         next: Arc<
             dyn AsyncEngine<SingleIn<BackendInput>, ManyOut<Annotated<BackendOutput>>, Error>,
         >,
-    ) -> Result<ManyOut<Annotated<ChatCompletionResponseDelta>>, Error> {
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
         // unpack the request
         let (request, context) = request.into_parts();
 
@@ -281,7 +281,7 @@ impl
         let common_request = context.map(|_| common_request);
 
         // create a stream of annotations this will be prepend to the response stream
-        let annotations: Vec<Annotated<ChatCompletionResponseDelta>> = annotations
+        let annotations: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = annotations
             .into_iter()
             .flat_map(|(k, v)| Annotated::from_annotation(k, &v))
             .collect();

--- a/lib/llm/src/protocols/codec.rs
+++ b/lib/llm/src/protocols/codec.rs
@@ -640,7 +640,7 @@ data: [DONE]
 
     #[tokio::test]
     async fn test_openai_chat_stream() {
-        use crate::protocols::openai::chat_completions::ChatCompletionResponseDelta;
+        use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
 
         // let cursor = Cursor::new(SAMPLE_CHAT_DATA);
         // let mut framed = FramedRead::new(cursor, SseLineCodec::new());
@@ -652,7 +652,7 @@ data: [DONE]
         loop {
             match stream.next().await {
                 Some(Ok(message)) => {
-                    let delta: ChatCompletionResponseDelta =
+                    let delta: NvCreateChatCompletionStreamResponse =
                         serde_json::from_str(&message.data.unwrap()).unwrap();
                     counter += 1;
                     println!("counter: {}", counter);

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -47,7 +47,7 @@ pub struct ChatCompletionContent {
 }
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
-pub struct ChatCompletionResponseDelta {
+pub struct NvCreateChatCompletionStreamResponse {
     #[serde(flatten)]
     pub inner: async_openai::types::CreateChatCompletionStreamResponse,
 }

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{ChatCompletionResponseDelta, NvCreateChatCompletionRequest};
+use super::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse};
 use crate::protocols::common;
 
 impl NvCreateChatCompletionRequest {
@@ -135,11 +135,13 @@ impl DeltaGenerator {
     }
 }
 
-impl crate::protocols::openai::DeltaGeneratorExt<ChatCompletionResponseDelta> for DeltaGenerator {
+impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamResponse>
+    for DeltaGenerator
+{
     fn choice_from_postprocessor(
         &mut self,
         delta: crate::protocols::common::llm_backend::BackendOutput,
-    ) -> anyhow::Result<ChatCompletionResponseDelta> {
+    ) -> anyhow::Result<NvCreateChatCompletionStreamResponse> {
         // aggregate usage
         if self.options.enable_usage {
             self.usage.completion_tokens += delta.token_ids.len() as u32;
@@ -163,7 +165,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<ChatCompletionResponseDelta> fo
         let index = 0;
         let stream_response = self.create_choice(index, delta.text, finish_reason, logprobs);
 
-        Ok(ChatCompletionResponseDelta {
+        Ok(NvCreateChatCompletionStreamResponse {
             inner: stream_response,
         })
     }

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -38,8 +38,8 @@ pub mod openai {
         use super::*;
 
         pub use protocols::openai::chat_completions::{
-            ChatCompletionResponseDelta, NvCreateChatCompletionRequest,
-            NvCreateChatCompletionResponse,
+            NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
+            NvCreateChatCompletionStreamResponse,
         };
 
         /// A [`UnaryEngine`] implementation for the OpenAI Chat Completions API
@@ -49,7 +49,7 @@ pub mod openai {
         /// A [`ServerStreamingEngine`] implementation for the OpenAI Chat Completions API
         pub type OpenAIChatCompletionsStreamingEngine = ServerStreamingEngine<
             NvCreateChatCompletionRequest,
-            Annotated<ChatCompletionResponseDelta>,
+            Annotated<NvCreateChatCompletionStreamResponse>,
         >;
     }
 }


### PR DESCRIPTION
#### What does the PR do?

Rename `ChatCompletionResponseDelta` to `NvCreateChatCompletionStreamResponse`.

```rust
// previously ChatCompletionResponseDelta
#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
pub struct NvCreateChatCompletionStreamResponse {
    #[serde(flatten)]
    pub inner: async_openai::types::CreateChatCompletionStreamResponse,
}
```

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [X] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [X] Added [test plan](#test-plan) and verified test passes.
- [X] Verified that the PR passes existing CI.
- [X] Verified copyright is correct on all changed files.
- [X] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] All template sections are filled out.
- [X] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:

- [X] refactor

#### Related PRs:
https://github.com/triton-inference-server/triton_distributed/pull/261

#### Where should the reviewer start?
`lib/llm/protocols/openai/chat_completions.rs`

#### Test plan:
No tests added. Global search-and-replace.

#### Caveats:
N/A

#### Background
https://github.com/triton-inference-server/triton_distributed/pull/261#issuecomment-2686039733

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #283 
