### PR TITLE
refactor: removes wrapper for ChatCompletionContent and adds documentation

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -27,6 +27,13 @@ mod delta;
 pub use aggregator::DeltaAggregator;
 pub use delta::DeltaGenerator;
 
+/// A request structure for creating a chat completion, extending OpenAI's
+/// `CreateChatCompletionRequest` with [`NvExt`] extensions.
+///
+/// # Fields
+/// - `inner`: The base OpenAI chat completion request, embedded using `serde(flatten)`.
+/// - `nvext`: The optional NVIDIA extension field. See [`NvExt`] for
+///   more details.
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
 pub struct NvCreateChatCompletionRequest {
     #[serde(flatten)]
@@ -34,41 +41,61 @@ pub struct NvCreateChatCompletionRequest {
     pub nvext: Option<NvExt>,
 }
 
+/// A response structure for unary chat completion responses, embedding OpenAI's
+/// `CreateChatCompletionResponse`.
+///
+/// # Fields
+/// - `inner`: The base OpenAI unary chat completion response, embedded
+///   using `serde(flatten)`.
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
 pub struct NvCreateChatCompletionResponse {
     #[serde(flatten)]
     pub inner: async_openai::types::CreateChatCompletionResponse,
 }
 
-#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
-pub struct ChatCompletionContent {
-    #[serde(flatten)]
-    pub inner: async_openai::types::ChatCompletionStreamResponseDelta,
-}
-
+/// A response structure for streamed chat completions, embedding OpenAI's
+/// `CreateChatCompletionStreamResponse`.
+///
+/// # Fields
+/// - `inner`: The base OpenAI streaming chat completion response, embedded
+///   using `serde(flatten)`.
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
 pub struct NvCreateChatCompletionStreamResponse {
     #[serde(flatten)]
     pub inner: async_openai::types::CreateChatCompletionStreamResponse,
 }
 
+/// Implements `NvExtProvider` for `NvCreateChatCompletionRequest`,
+/// providing access to NVIDIA-specific extensions.
 impl NvExtProvider for NvCreateChatCompletionRequest {
+    /// Returns a reference to the optional `NvExt` extension, if available.
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
     }
 
+    /// Returns `None`, as raw prompt extraction is not implemented.
     fn raw_prompt(&self) -> Option<String> {
         None
     }
 }
 
+/// Implements `AnnotationsProvider` for `NvCreateChatCompletionRequest`,
+/// enabling retrieval and management of request annotations.
 impl AnnotationsProvider for NvCreateChatCompletionRequest {
+    /// Retrieves the list of annotations from `NvExt`, if present.
     fn annotations(&self) -> Option<Vec<String>> {
         self.nvext
             .as_ref()
             .and_then(|nvext| nvext.annotations.clone())
     }
 
+    /// Checks whether a specific annotation exists in the request.
+    ///
+    /// # Arguments
+    /// * `annotation` - A string slice representing the annotation to check.
+    ///
+    /// # Returns
+    /// `true` if the annotation exists, `false` otherwise.
     fn has_annotation(&self, annotation: &str) -> bool {
         self.nvext
             .as_ref()
@@ -78,47 +105,72 @@ impl AnnotationsProvider for NvCreateChatCompletionRequest {
     }
 }
 
+/// Implements `OpenAISamplingOptionsProvider` for `NvCreateChatCompletionRequest`,
+/// exposing OpenAI's sampling parameters for chat completion.
 impl OpenAISamplingOptionsProvider for NvCreateChatCompletionRequest {
+    /// Retrieves the temperature parameter for sampling, if set.
     fn get_temperature(&self) -> Option<f32> {
         self.inner.temperature
     }
 
+    /// Retrieves the top-p (nucleus sampling) parameter, if set.
     fn get_top_p(&self) -> Option<f32> {
         self.inner.top_p
     }
 
+    /// Retrieves the frequency penalty parameter, if set.
     fn get_frequency_penalty(&self) -> Option<f32> {
         self.inner.frequency_penalty
     }
 
+    /// Retrieves the presence penalty parameter, if set.
     fn get_presence_penalty(&self) -> Option<f32> {
         self.inner.presence_penalty
     }
 
+    /// Returns a reference to the optional `NvExt` extension, if available.
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
     }
 }
 
+/// Implements `OpenAIStopConditionsProvider` for `NvCreateChatCompletionRequest`,
+/// providing access to stop conditions that control chat completion behavior.
 #[allow(deprecated)]
 impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
+    /// Retrieves the maximum number of tokens allowed in the response.
+    ///
+    /// # Note
+    /// This field is deprecated in favor of `max_completion_tokens`.
     fn get_max_tokens(&self) -> Option<u32> {
         // ALLOW: max_tokens is deprecated in favor of max_completion_tokens
         self.inner.max_tokens
     }
 
+    /// Retrieves the minimum number of tokens required in the response.
+    ///
+    /// # Note
+    /// This method is currently a placeholder and always returns `None`
+    /// since `min_tokens` is not an OpenAI-supported parameter.
     fn get_min_tokens(&self) -> Option<u32> {
-        // TODO THIS IS WRONG min_tokens does not exist
         None
     }
 
+    /// Retrieves the stop conditions that terminate the chat completion response.
+    ///
+    /// Converts OpenAI's `Stop` enum to a `Vec<String>`, normalizing the representation.
+    ///
+    /// # Returns
+    /// * `Some(Vec<String>)` if stop conditions are set.
+    /// * `None` if no stop conditions are defined.
     fn get_stop(&self) -> Option<Vec<String>> {
-        // TODO THIS IS WRONG should instead do
-        // Vec<String> -> async_openai::types::Stop
-        // self.inner.stop.clone()
-        None
+        self.inner.stop.as_ref().map(|stop| match stop {
+            async_openai::types::Stop::String(s) => vec![s.clone()],
+            async_openai::types::Stop::StringArray(arr) => arr.clone(),
+        })
     }
 
+    /// Returns a reference to the optional `NvExt` extension, if available.
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
     }


### PR DESCRIPTION
#### What does the PR do?
Removes wrapper for `ChatCompletionContent` and adds documentation to all `openai::chat_completions::*`.

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [X] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [X] Added [test plan](#test-plan) and verified test passes.
- [X] Verified that the PR passes existing CI.
- [X] Verified copyright is correct on all changed files.
- [X] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] All template sections are filled out.
- [X] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:

- [X] refactor

#### Related PRs:
https://github.com/triton-inference-server/triton_distributed/pull/261

#### Where should the reviewer start?
`lib/llm/protocols/openai/chat_completions.rs`

#### Test plan:
No tests added. Global search-and-replace.

#### Caveats:
N/A

#### Background
https://github.com/triton-inference-server/triton_distributed/pull/261#issuecomment-2686039733

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #283 
