### PR TITLE
[fix] KV Router Example fixes 

### DIFF
--- a/examples/python_rs/llm/vllm/kv_router/router.py
+++ b/examples/python_rs/llm/vllm/kv_router/router.py
@@ -67,7 +67,7 @@ class Router:
             # catch specific router exceptions once we have dedicated types.
             except Exception as e:
                 vllm_logger.info(f"{e}")
-                worker_id = None
+                worker_id = ""
                 vllm_logger.exception(f"Error during worker selection: {e}")
 
             vllm_logger.info(f"Scheduling to worker_id: {worker_id}")

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -69,7 +69,7 @@ impl KvMetricsPublisher {
         })
     }
 
-    fn create_service<'p>(
+    fn create_endpoint<'p>(
         &self,
         py: Python<'p>,
         component: Component,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -17,7 +17,6 @@ use anyhow::Result;
 use futures::stream::StreamExt;
 use std::{sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
-use tracing as log;
 use tracing;
 use triton_distributed_runtime::{component::Component, DistributedRuntime};
 
@@ -29,7 +28,7 @@ mod scoring;
 
 use crate::kv_router::{
     indexer::{KvIndexer, KvIndexerInterface, RouterEvent},
-    scheduler::{Endpoint, FlexibleService, KvScheduler, Service},
+    scheduler::{Endpoint, KvScheduler, Service},
     scoring::ProcessedEndpoints,
 };
 
@@ -57,8 +56,8 @@ impl KvRouter {
         let nats_client = runtime.nats_client();
         let service_name = backend.service_name();
         let kv_subject = backend.event_subject(KV_EVENT_SUBJECT);
-        log::info!("Component Service Name {}", service_name);
-        log::info!("KV Subject {}", kv_subject);
+        tracing::info!("Component Service Name {}", service_name);
+        tracing::info!("KV Subject {}", kv_subject);
         Self::new(nats_client, service_name, kv_subject).await
     }
 
@@ -80,16 +79,16 @@ impl KvRouter {
         let indexer = KvIndexer::new(cancellation_token.clone());
         let scheduler = KvScheduler::start(ep_rx).await?;
 
-        log::debug!("subscribing to kv events: {}", kv_subject);
+        tracing::debug!("subscribing to kv events: {}", kv_subject);
         let mut kv_events_rx = nats_client.client().subscribe(kv_subject).await?;
         let kv_events_tx = indexer.event_sender();
 
         tokio::spawn(async move {
             while let Some(event) = kv_events_rx.next().await {
                 let event: RouterEvent = serde_json::from_slice(&event.payload).unwrap();
-                log::debug!("received kv event: {:?}", event);
+                tracing::debug!("received kv event: {:?}", event);
                 if let Err(e) = kv_events_tx.send(event).await {
-                    log::trace!("failed to send kv event to indexer; shutting down: {:?}", e);
+                    tracing::trace!("failed to send kv event to indexer; shutting down: {:?}", e);
                 }
             }
         });
@@ -119,7 +118,7 @@ impl KvRouter {
             .indexer
             .find_matches_for_request(token_ids.as_slice())
             .await?;
-        log::debug!("KV router overlap_scores: {:?}", overlap_scores);
+        tracing::debug!("KV router overlap_scores: {:?}", overlap_scores);
         let worker_id = self.scheduler.schedule(overlap_scores, isl_tokens).await?;
         Ok(worker_id)
     }
@@ -134,11 +133,11 @@ async fn collect_endpoints(
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
-                log::debug!("cancellation token triggered");
+                tracing::debug!("cancellation token triggered");
                 break;
             }
             _ = tokio::time::sleep(Duration::from_secs(1)) => {
-                log::trace!("collecting endpoints for service: {}", service_name);
+                tracing::trace!("collecting endpoints for service: {}", service_name);
             }
         }
 
@@ -148,18 +147,14 @@ async fn collect_endpoints(
             .unwrap();
 
         tracing::debug!("values: {:?}", values);
-        let services: Vec<FlexibleService> = values
+        let services: Vec<Service> = values
             .into_iter()
             .filter(|v| !v.is_empty())
-            .filter_map(|v| {
-                match serde_json::from_slice::<FlexibleService>(&v) {
-                    Ok(service) => {
-                        Some(service)
-                    },
-                    Err(e) => {
-                        tracing::warn!("For value: {:?} \nFailed to parse service: {:?}", v, e);
-                        None
-                    }
+            .filter_map(|v| match serde_json::from_slice::<Service>(&v) {
+                Ok(service) => Some(service),
+                Err(e) => {
+                    tracing::warn!("For value: {:?} \nFailed to parse service: {:?}", v, e);
+                    None
                 }
             })
             .collect();
@@ -173,10 +168,11 @@ async fn collect_endpoints(
                 name: s.name,
                 subject: s.subject,
                 data: s.data.unwrap(),
-            }).collect();
+            })
+            .collect();
         tracing::debug!("endpoints: {:?}", endpoints);
 
-        log::trace!(
+        tracing::trace!(
             "found {} endpoints for service: {}",
             endpoints.len(),
             service_name
@@ -186,7 +182,7 @@ async fn collect_endpoints(
 
         // process endpoints into
         if ep_tx.send(processed).await.is_err() {
-            log::trace!("failed to send processed endpoints; shutting down");
+            tracing::trace!("failed to send processed endpoints; shutting down");
             break;
         }
     }

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -95,9 +95,6 @@ impl KvMetricsPublisher {
         let handler = Ingress::for_engine(handler)?;
 
         component
-            .service_builder()
-            .create()
-            .await?
             .endpoint("load_metrics")
             .endpoint_builder()
             .stats_handler(move |_| {

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -64,21 +64,12 @@ impl Endpoint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FlexibleService {
-    pub name: String,
-    pub id: String,
-    pub version: String,
-    pub started: String,
-    pub endpoints: Vec<FlexibleEndpoint>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Service {
     pub name: String,
     pub id: String,
     pub version: String,
     pub started: String,
-    pub endpoints: Vec<Endpoint>,
+    pub endpoints: Vec<FlexibleEndpoint>,
 }
 
 pub struct SchedulingRequest {

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -35,6 +35,13 @@ pub enum KvSchedulerError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlexibleEndpoint {
+    pub name: String,
+    pub subject: String,
+    pub data: Option<ForwardPassMetrics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Endpoint {
     pub name: String,
     pub subject: String,
@@ -54,6 +61,15 @@ impl Endpoint {
         )
         .expect("invalid worker id")
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlexibleService {
+    pub name: String,
+    pub id: String,
+    pub version: String,
+    pub started: String,
+    pub endpoints: Vec<FlexibleEndpoint>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
#### What does the PR do?
This https://github.com/triton-inference-server/triton_distributed/pull/282 change caused the KV Routing example to break. This fixes those problems

- Only run .service_builder().create() once for a given endpoint
- handle the case where metrics are sent from endpoints without metrics_handlers and the data field is null

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.

- [ x] fix
