### PR TITLE
ci: Remove GitHub Actions variable references so forks trigger the pr_github_validation workflow

### DIFF
--- a/.github/workflows/pr_github_validation.yaml
+++ b/.github/workflows/pr_github_validation.yaml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   build-test:
-    runs-on: ${{ fromJSON(vars.PR_FASTCHECK_RUNNERS) }}
+    runs-on: 
+      group: Fastchecker
     strategy:
       matrix:
         framework:


### PR DESCRIPTION
#### What does the PR do?
Pull requests from forks to the `triton_distributed` repo are not currently triggering the `pr_github_validation.yaml` workflow as the `on: pull_request` executes within the context of the fork rather than `triton-inference-server/triton_distributed` so it does not have access to the Github Actions variable `PR_FASTCHECK_RUNNERS` so the workflow job is invalid and will not get run.

By hardcoding the `runs-on` to our large GitHub runner group `group: Fastchecker` we have observed it functioning from a PR from a fork [PR from fork 312 (closed)](https://github.com/triton-inference-server/triton_distributed/pull/312/files) (ignore the build failure due to permissions, being addressed elsewhere).


#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [x] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
[PR from fork 312 (closed)](https://github.com/triton-inference-server/triton_distributed/pull/312/files): shows that updating the `runs-on` field allows the workflow job to access the runner group within `triton-inference-server`

#### Where should the reviewer start?
`.github/workflows/pr_github_validation.yaml`

#### Test plan:
Once merged we should make a PR from a fork to ensure it executes

- CI Pipeline ID:
N/A

#### Caveats:
Fork PRs will not make use of caching and docker images will not be stored as artifacts or in the container registry

#### Background
Attempt to accept a fork PR as a test indicated that the expected workflows were not running

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A