### PR TITLE
chore: Tweak prometheus/grafana config defaults

### DIFF
--- a/applications/llm/count/visualization/docker-compose.yml
+++ b/applications/llm/count/visualization/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     container_name: prometheus
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -42,12 +41,13 @@ services:
       - ./grafana.json:/etc/grafana/provisioning/dashboards/llm-worker-dashboard.json
       - ./grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml
       - ./grafana-dashboard-providers.yml:/etc/grafana/provisioning/dashboards/dashboard-providers.yml
-      - grafana_data:/var/lib/grafana
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_INSTALL_PLUGINS=grafana-piechart-panel
+      # Default min interval is 5s, but can be configured lower
+      - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=2s
     restart: unless-stopped
     # TODO: Use more explicit networking setup when count is containerized
     #ports:
@@ -61,7 +61,3 @@ services:
 networks:
   monitoring:
     driver: bridge
-
-volumes:
-  prometheus_data:
-  grafana_data:

--- a/applications/llm/count/visualization/grafana.json
+++ b/applications/llm/count/visualization/grafana.json
@@ -572,7 +572,7 @@
       ]
     }
   ],
-  "refresh": "5s",
+  "refresh": "2s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
@@ -584,8 +584,8 @@
       {
         "current": {
           "selected": false,
-          "text": "backend",
-          "value": "backend"
+          "text": "component",
+          "value": "vllm"
         },
         "datasource": {
           "type": "prometheus",
@@ -611,8 +611,8 @@
       {
         "current": {
           "selected": false,
-          "text": "generate",
-          "value": "generate"
+          "text": "endpoint",
+          "value": "load_metrics"
         },
         "datasource": {
           "type": "prometheus",
@@ -638,7 +638,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
Changes:
- Tweak grafana defaults for more to be more ergonomic for quickstart and local testing
    - ref on min refresh interval: https://github.com/grafana/grafana/issues/710#issuecomment-1913545694
- Remove unused docker volumes to simplify docker-compose.yml

Example usage:
```
# Start prometheus server + grafana dashboard containers: http://<IP>:3000/d/llm-worker-metrics/llm-worker-metrics
cd applications/llm/count/visualization
docker compose up -d

# Start count pointing at namespace/component/endpoint of kv routing metrics
cd applications/llm/count
TRD_LOG=info cargo run --bin count -- --namespace triton-init --component vllm --endpoint load_metrics

# Start kv routing example
# 2 workers, prefix strategy
cd examples/python_rs/llm/vllm
./scripts/kv-router-run.sh 2 prefix deepseek-ai/DeepSeek-R1-Distill-Llama-8B
```