### PR TITLE
[DRAFT] feat(bindings): Expose etcd-client in python distributed runtime

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -62,6 +62,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Component>()?;
     m.add_class::<Endpoint>()?;
     m.add_class::<Client>()?;
+    m.add_class::<EtcdClient>()?;
     m.add_class::<AsyncResponseStream>()?;
     m.add_class::<llm::kv::KvRouter>()?;
     m.add_class::<llm::kv::KvMetricsPublisher>()?;
@@ -83,6 +84,12 @@ where
 struct DistributedRuntime {
     inner: rs::DistributedRuntime,
     event_loop: PyObject,
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct EtcdClient {
+    inner: rs::transports::etcd::Client,
 }
 
 #[pyclass]
@@ -146,6 +153,12 @@ impl DistributedRuntime {
         Ok(Namespace {
             inner: self.inner.namespace(name).map_err(to_pyerr)?,
             event_loop: self.event_loop.clone(),
+        })
+    }
+
+    fn etcd_client(&self) -> PyResult<EtcdClient> {
+        Ok(EtcdClient {
+            inner: self.inner.etcd_client().clone(),
         })
     }
 
@@ -248,6 +261,27 @@ impl Namespace {
         Ok(Component {
             inner,
             event_loop: self.event_loop.clone(),
+        })
+    }
+}
+
+#[pymethods]
+impl EtcdClient {
+    #[pyo3(signature = (key, value, lease_id=None))]
+    fn kv_create_or_validate<'p>(
+        &self,
+        py: Python<'p>,
+        key: String,
+        value: Vec<u8>,
+        lease_id: Option<i64>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let client = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .kv_create_or_validate(key, value, lease_id)
+                .await
+                .map_err(to_pyerr)?;
+            Ok(())
         })
     }
 }

--- a/lib/bindings/python/src/triton_distributed/_core.pyi
+++ b/lib/bindings/python/src/triton_distributed/_core.pyi
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import AsyncGenerator, AsyncIterator, Callable, List
+from typing import AsyncGenerator, AsyncIterator, Callable, List, Optional
 
 class JsonLike:
     """
@@ -34,6 +34,22 @@ class DistributedRuntime:
     def namespace(self, name: str, path: str) -> Namespace:
         """
         Create a `Namespace` object
+        """
+        ...
+
+    def etcd_client(self) -> EtcdClient:
+        """
+        Get the `EtcdClient` object
+        """
+        ...
+
+class EtcdClient:
+    """
+    Etcd is used for discovery in the DistributedRuntime
+    """
+    async def kv_create_or_validate(self, key: str, value: bytes, lease_id: Optional[int] = None) -> None:
+        """
+        Atomically create a key if it does not exist, or validate the values are identical if the key exists.
         """
         ...
 


### PR DESCRIPTION
## Overview
This PR exposes the EtcdClient functionality to Python bindings and updates the core.pyi file to reflect these changes. It enhances the capabilities of the DistributedRuntime by providing access to Etcd operations.

## Detailed breakdown and reasoning
The addition of EtcdClient functionality allows Python users to interact with Etcd allowing us to leverage it for runtime discovery. Exposing this functionality will be helpful when it comes time to deploy NIXL on multiple nodes. As of now I have only exposed the `kv_create_or_validate` functionality.

## Changes Made
- Added EtcdClient class to Rust bindings
- Exposed EtcdClient through DistributedRuntime in Rust
- Implemented kv_create_or_validate method for EtcdClient
- Updated core.pyi to include EtcdClient and its methods
- Added etcd_client() method to DistributedRuntime in Python bindings