### PR TITLE
fix: Fix nixl install / PYTHONPATH in both dev and runtime targets

### DIFF
--- a/container/Dockerfile.vllm_nixl
+++ b/container/Dockerfile.vllm_nixl
@@ -49,9 +49,14 @@ RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/
 ### NIXL SETUP ###
 
 ARG MOFED_VERSION=5.8-1.1.2.1
-ARG PYTHON_VERSION=3.12
 ARG NSYS_URL=https://developer.nvidia.com/downloads/assets/tools/secure/nsight-systems/2024_4/
 ARG NSYS_PKG=NsightSystems-linux-cli-public-2024.4.1.61-3431596.deb
+# Set environment variables for nixl
+ARG PYTHON_VERSION=3.12
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+ENV PYTHONPATH=/usr/local/nixl/lib/python${PYTHON_VERSION}/site-packages/:/opt/nixl/test/python/:$PYTHONPATH
+
+
 
 RUN apt-get update -y && apt-get -y install curl \
                                             git \
@@ -281,11 +286,12 @@ COPY --from=dev /usr/local/nixl /usr/local/nixl
 COPY --from=dev /opt/nixl /opt/nixl
 
 # Set environment variables for nixl
+ARG PYTHON_VERSION=3.12
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 ENV PYTHONPATH=/usr/local/nixl/lib/python${PYTHON_VERSION}/site-packages/:/opt/nixl/test/python/:$PYTHONPATH
 
 # Copy venv with installed packages
-RUN uv python install 3.12
+RUN uv python install ${PYTHON_VERSION}
 COPY --from=dev /opt/vllm /opt/vllm
 COPY --from=dev ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 


### PR DESCRIPTION
See https://github.com/triton-inference-server/triton_distributed/pull/325/files#r1976746070

Before:
```bash
# Both runtime and dev images fail to import nixl
ModuleNotFoundError: No module named 'nixl_bindings'
```

After:
```bash
# Build runtime and dev images
./container/build.sh --framework vllm_nixl --build-context nixl=/home/rmccormick/triton/distributed/nixl
./container/build.sh --framework vllm_nixl --build-context nixl=/home/rmccormick/triton/distributed/nixl --target dev

# Runtime nixl import works
./container/run.sh --framework vllm_nixl -it --hf-cache ~/.cache/huggingface -- python -c "import nixl_bindings"

# Dev nixl import works
./container/run.sh --framework vllm_nixl -it --hf-cache ~/.cache/huggingface --target dev -- python -c "import nixl_bindings"
```