### PR TITLE
refactor: Upgrade Rust to 1.85.0

### DIFF
--- a/launch/tio/rust-toolchain.toml
+++ b/launch/tio/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/lib/bindings/python/rust-toolchain.toml
+++ b/lib/bindings/python/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/lib/llm/rust-toolchain.toml
+++ b/lib/llm/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/lib/runtime/rust-toolchain.toml
+++ b/lib/runtime/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"


### PR DESCRIPTION
- CI needs it to pass
- It's a good thing anyway
