### PR TITLE
fix: Install specific toolchain

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -66,6 +66,7 @@ jobs:
       if: ${{ env.ACT }}
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Set up Rust Toolchain Components
       run: rustup component add rustfmt clippy

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
 
 # Install OpenAI-compatible frontend and its dependencies from triton server
 # repository. These are used to have a consistent interface, schema, and FastAPI

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -69,6 +69,7 @@ RUN apt update -y && \
     pkg-config && \
     curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
 
 # Working directory
 WORKDIR /workspace

--- a/container/Dockerfile.vllm_nixl
+++ b/container/Dockerfile.vllm_nixl
@@ -199,6 +199,7 @@ RUN apt update -y && \
     pkg-config && \
     curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
 
 # Working directory
 WORKDIR /workspace

--- a/launch/tio/rust-toolchain.toml
+++ b/launch/tio/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/lib/bindings/python/rust-toolchain.toml
+++ b/lib/bindings/python/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/lib/llm/rust-toolchain.toml
+++ b/lib/llm/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/lib/runtime/rust-toolchain.toml
+++ b/lib/runtime/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"


### PR DESCRIPTION
`cargo build --locked` won't let you use "1.85.0" if you only have "stable" installed, even if those are the same thing right now.
